### PR TITLE
Clean up Gatsby logging

### DIFF
--- a/makefiles/Makefile.docs-node
+++ b/makefiles/Makefile.docs-node
@@ -34,7 +34,7 @@ next-gen-html:
 	echo "GATSBY_SITE=${PROJECT}" > .env.production; \
 	echo "GATSBY_PARSER_USER=${USER}" >> .env.production; \
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
-	npm run build; \
+	npm run build -- --no-color; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 stage: ## Host online for review


### PR DESCRIPTION
Use Gatsby's [`--no-color`](https://www.gatsbyjs.org/docs/gatsby-cli/#build) flag to simplify logging output.