### PR TITLE
clean push of Dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,11 @@ WORKDIR /home/docsworker
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty
 RUN python3 -m pip install --upgrade pip flit
-RUN git clone https://github.com/mongodb/snooty-parser.git snooty-parser && \
+RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
-	git fetch --all && \
-	git reset --hard origin/master && \
+	git fetch --tags && \
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
+	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
 ENV PATH="${PATH}:/home/docsworker/.local/bin"
 

--- a/Dockerfile.xlarge
+++ b/Dockerfile.xlarge
@@ -33,10 +33,11 @@ WORKDIR /home/docsworker-xlarge
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty
 RUN python3 -m pip install --upgrade pip flit
-RUN git clone https://github.com/mongodb/snooty-parser.git snooty-parser && \
+RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
-	git fetch --all && \
-	git reset --hard origin/master && \
+	git fetch --tags && \
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
+	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
 ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin"
 


### PR DESCRIPTION
This PR binds our Dockerfile and Dockerfile.xlarge to tagged releases only of the snooty-parser.

To test, please build and instance of the Docker image and run it locally against pool_test. Publish a change and make sure that the results are as expected.

Test must be run against the following repositories using next-gen configurations:

-- docs-ecosystem
-- docs-node

