### PR TITLE
adding deploy target for next gen

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -53,6 +53,7 @@ next-gen-stage: ## Host online for review
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
 
 deploy: build/public ## Deploy to the production bucket
+	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
 	mut-publish build/public ${PRODUCTION_BUCKET} --prefix=${PROJECT} --deploy --all-subdirectories ${ARGS}
 
 	@echo "Hosted at ${PRODUCTION_URL}/index.html"


### PR DESCRIPTION
Pull request for changes in the Makefile.devhub-content to accommodate publishing to the new S3 buckets.

This fix requires a change to the deploy target in the workerpool node layer.