### PR TITLE
devhub content

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -28,12 +28,12 @@ help: ## Show this help message
 update-snooty:
 	@git clone https://${GITHUB_USER}:${GITHUB_PASS}@github.com/10gen/dev-hub snooty && \
 	cd snooty && \
-	git checkout staging && \
-	npm install && \
-	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
-	mkdir -p ./static/images && \
-	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
+	git checkout master && \
+	npm install
+	#  git clone https://github.com/mongodb/docs-tools.git docs-tools && \
+	# mkdir -p ./static/images && \
+	# mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
+	# mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
 
 next-gen-html: update-snooty
 	# snooty parse and then build-front-end


### PR DESCRIPTION
This PR changes the branch of the snooty frontend code used to render the developer.mongodb.com from stage to master.

To test:

1. Fork the https://github.com/mongodb/devhub-content repository
2. Make sure you have added the github webhook for the autobuilder to your fork
3. checkout a new branch, make a change, commit and push your change
4. If you have properly configured your autobuilder hook, you should get a link with your new staged content with changes via slack.


