### PR TITLE
DOP-919

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -46,7 +46,6 @@ next-gen-html: update-snooty
 
 next-gen-html-publish: update-snooty
 	# snooty parse and then build-front-end
-	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/devhub-content.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR} && \
 	curl https://raw.githubusercontent.com/mongodb/devhub/master/gatsby-config.prod.js > ${REPO_DIR}/snooty-devhub/gatsby-config.js

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -46,6 +46,7 @@ next-gen-html: update-snooty
 
 next-gen-html-publish: update-snooty
 	# snooty parse and then build-front-end
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/devhub-content.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR} && \
 	curl https://raw.githubusercontent.com/mongodb/devhub/master/gatsby-config.prod.js > ${REPO_DIR}/snooty-devhub/gatsby-config.js

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -28,6 +28,7 @@ html: ## Builds this branch's HTML under build/<branch>/html
 
 next-gen-html:
 	# snooty parse and then build-front-end
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	cp -r ${REPO_DIR}/../../snooty ${REPO_DIR};
 	cd snooty; \
@@ -39,7 +40,6 @@ next-gen-html:
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
-	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
 	
@@ -49,6 +49,8 @@ next-gen-publish:
 publish: ## Builds this branch's publishable HTML and other artifacts under build/public
 	giza make publish
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
+
+STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
 stage: ## Host online for review
 	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
@@ -61,6 +63,14 @@ deploy: build/public ## Deploy to the production bucket
 
 	$(MAKE) deploy-search-index
 
+next-gen-deploy: build/public ## Deploy to the production bucket
+	mut-publish build/public ${PRODUCTION_BUCKET} --prefix=${PROJECT} --deploy --redirect-prefix='bi-connector' ${ARGS}
+
+	@echo "Hosted at ${PRODUCTION_URL}/${PROJECT}/index.html"
+
+	$(MAKE) next-gen-deploy-search-index
+	
+
 deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
 	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
@@ -68,6 +78,14 @@ deploy-search-index: ## Update the search index for this branch
 	else \
 		mut-index upload build/public/${GIT_BRANCH} -o bi-connector-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
 	fi
-
+	
+next-gen-deploy-search-index: ## Update the search index for this branch
+	@echo "Building search index"
+	if [ ${STABLE_BRANCH_NEXT_GEN} = ${GIT_BRANCH} ]; then \
+		mut-index upload build/public/${GIT_BRANCH} -o bi-connector-current.json --aliases bi-connector-${GIT_BRANCH} -u ${PRODUCTION_URL}/${PROJECT}/current -g -s; \
+	else \
+		mut-index upload build/public/${GIT_BRANCH} -o bi-connector-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
+	fi
+	
 redirects:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -39,7 +39,7 @@ next-gen-html:
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
-  curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
 	

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -39,7 +39,7 @@ next-gen-html:
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
-STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' ${REPO_DIR}/published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+STABLE_BRANCH_NEXT_GEN = `grep 'manual' ${REPO_DIR}/published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
 next-gen-stage: ## Host online for review
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -39,6 +39,7 @@ next-gen-html:
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
+  curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
 	

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -51,7 +51,6 @@ publish: ## Builds this branch's publishable HTML and other artifacts under buil
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
 
 stage: ## Host online for review
-	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${PROJECT}/${USER}/${GIT_BRANCH}/index.html"
 

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -39,6 +39,8 @@ next-gen-html:
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
+STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+
 next-gen-stage: ## Host online for review
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
@@ -50,7 +52,6 @@ publish: ## Builds this branch's publishable HTML and other artifacts under buil
 	giza make publish
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
 
-STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
 stage: ## Host online for review
 	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -51,6 +51,7 @@ publish: ## Builds this branch's publishable HTML and other artifacts under buil
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
 
 stage: ## Host online for review
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
 	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${PROJECT}/${USER}/${GIT_BRANCH}/index.html"
 

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -39,7 +39,7 @@ next-gen-html:
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
-STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+STABLE_BRANCH_NEXT_GEN = STABLE_BRANCH=`grep 'manual' ${REPO_DIR}/published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
 next-gen-stage: ## Host online for review
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -71,7 +71,6 @@ next-gen-deploy: build/public ## Deploy to the production bucket
 
 	$(MAKE) next-gen-deploy-search-index
 	
-
 deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
 	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \

--- a/makefiles/Makefile.docs-datalake
+++ b/makefiles/Makefile.docs-datalake
@@ -17,8 +17,7 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.
-STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJEC
-T}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
 .PHONY: help html publish stage deploy deploy-search-index
 
@@ -55,14 +54,6 @@ deploy: build/public
 
 	$(MAKE) deploy-search-index
 
-## Update the search index for this branch
-deploy-search-index:
-	@echo "Building search index"
-	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-current.json --aliases ${PROJECT}-${GIT_BRANCH} -u ${PRODUCTION_URL}/${PROJECT}/stable -g -s; \
-	else \
-		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
-	fi
 	
 next-gen-html:
 	# snooty parse and then build-front-end
@@ -97,8 +88,24 @@ next-gen-publish:
 next-gen-deploy:
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix=${PROJECT} --deploy --all-subdirectories ${ARGS}
 	@echo "Hosted at ${PRODUCTION_URL}/${PROJECT}/index.html"
-	$(MAKE) deploy-search-index
-	
-deploy-search-index: ## Update the search index for this branch
+	$(MAKE) next-gen-deploy-search-index
+
+STABLE_BRANCH_NEXT_GEN=`grep 'manual' ${REPO_DIR}/published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+
+## Update the search index for this branch
+deploy-search-index:
 	@echo "Building search index"
-	mut-index upload build/public -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL} -s
+	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
+		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-current.json --aliases ${PROJECT}-${GIT_BRANCH} -u ${PRODUCTION_URL}/${PROJECT}/stable -g -s; \
+	else \
+		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
+	fi
+
+## Update the search index for this branch
+next-gen-deploy-search-index:
+	@echo "Building search index"
+	if [ ${STABLE_BRANCH_NEXT_GEN} = ${GIT_BRANCH} ]; then \
+		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-current.json --aliases ${PROJECT}-${GIT_BRANCH} -u ${PRODUCTION_URL}/${PROJECT}/stable -g -s; \
+	else \
+		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
+	fi

--- a/makefiles/Makefile.docs-datalake
+++ b/makefiles/Makefile.docs-datalake
@@ -82,6 +82,7 @@ next-gen-stage: ## Host online for review
 	
 next-gen-publish:
 	# snooty parse and then build-front-end
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-datalake.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/configfiles/docs-datalake/gatsby-config.js > ${REPO_DIR}/snooty/gatsby-config.js

--- a/makefiles/Makefile.docs-ecosystem
+++ b/makefiles/Makefile.docs-ecosystem
@@ -54,6 +54,7 @@ next-gen-html: assets
 
 next-gen-publish: assets
 	# snooty parse and then build-front-end
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-ecosystem.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/configfiles/docs-ecosystem/gatsby-config.js > ${REPO_DIR}/snooty/gatsby-config.js

--- a/makefiles/Makefile.docs-node
+++ b/makefiles/Makefile.docs-node
@@ -25,6 +25,7 @@ help: ## Show this help message
 
 next-gen-html-publish:
 	# snooty parse and then build-front-end
+	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/configfiles/docs-node/gatsby-config.js > ${REPO_DIR}/snooty/gatsby-config.js


### PR DESCRIPTION
[DOP-919](https://jira.mongodb.org/browse/DOP-919):
As the published-branches.yaml files already existed on autobuilder, my changes just include pulling the published-branches.yaml file into root of content repo root before parse

This was tested by running `make next-gen-publish` by deploying autobuilder on an ec2 instance and then pushing up a docs-node job via github webhook. It was verified by running `ls` that `published-branches.yaml` is successfully downloaded and also by verifying in the database.

This PR also includes a new target for docs-bi-connector deployment: next-gen-deploy. This target will have to be tested after a deployment to make sure it indexed properly. We will know it has indexed properly by making sure it is listed on https://marian.mongodb.com/status.