### PR TITLE
Update Makefile.docs-bi-connector for catching parser failure

### DIFF
--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -29,7 +29,12 @@ html: ## Builds this branch's HTML under build/<branch>/html
 next-gen-html:
 	# snooty parse and then build-front-end
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-bi-connector.yaml > ${REPO_DIR}/published-branches.yaml
-	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
+	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}";\
+		if [ $$? -eq 1 ]; then \
+			exit 1; \
+		else \
+			exit 0; \
+		fi
 	cp -r ${REPO_DIR}/../../snooty ${REPO_DIR};
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production; \


### PR DESCRIPTION
This makefile logic allows us to throw an error ONLY when parser throws error code 1 in the course of running `snooty build...`. 

We exit 0 on all other errors.