### PR TITLE
DOP-64 FIX

### DIFF
--- a/worker/jobTypes/githubJob.js
+++ b/worker/jobTypes/githubJob.js
@@ -314,14 +314,12 @@ class GitHubJobClass {
                 });
             });
         } catch (error) {
-          if (error.code === 1) {
-            logger.save(
-              `${'(BUILD)'.padEnd(15)}failed with code: ${error.code}`
-            );
-            logger.save(`${'(BUILD)'.padEnd(15)}stdErr: ${error.stderr}`);
-            logger.save(`${'(BUILD)'.padEnd(15)}stdout: ${error.stdout}`);
-            throw error;              
-          }
+          logger.save(
+            `${'(BUILD)'.padEnd(15)}failed with code: ${error.code}`
+          );
+          logger.save(`${'(BUILD)'.padEnd(15)}stdErr: ${error.stderr}`);
+          logger.save(`${'(BUILD)'.padEnd(15)}stdout: ${error.stdout}`);
+          throw error;              
         }
 
     }

--- a/worker/tests/unit/githubPushJob.unit.test.js
+++ b/worker/tests/unit/githubPushJob.unit.test.js
@@ -107,7 +107,6 @@ describe('Test Class', () => {
     devhubjob.cloneRepo = jest.fn().mockResolvedValue();
     
     const mockError = new Error()
-    mockError.code = 1
     const execMock = jest.fn().mockResolvedValueOnce({stdout: 'success', stderr: ''});
     workerUtils.getExecPromise = jest.fn().mockReturnValueOnce(() => execMock)
                                           .mockReturnValue(() => { throw mockError});


### PR DESCRIPTION
**Overview:**
The goal of DOP-64 was to catch and log parser failures. However, the initial fix relied on checking the error's code. On the parser side, it throws an error code 1 for parser failures and error code 2 for all other diagnostic errors. 

However, make propagates all errors as error code 2. This meant on the server side we couldn't differentiate error codes without parsing stderr, which is a brittle and weak solution. 

I was eventually able to write the conditional I needed in the next-gen-html target ([demonstrated in this PR](https://github.com/mongodb/docs-worker-pool/pull/197), which you will need to test _this_ PR). In this way, we can differentiate error codes from within the makefile. 

note to andrew: the initial condition we tried `if [$? -eq 1]; then exit 1; else exit 0; fi` had some syntax issues and was causing some silent failures.

**Testing the PR:** 

Because my tests require makefile changes and docs content changes, I had a somewhat unique approach.

In my local staging env, I altered the server to download the makefile from my fork's meta branch, which contained the code from PR-197. Boot up your staging env. 

Then, in my fork of a docs-bi-connector job, I introduce invalid toml in my snooty.toml as invalid toml causes parser failure - which we are testing for. In this case I changed, `name = "bi-connector"` to `name = invalid` 

I commit this change and push, enqueuing a job. 

Watching either the console of your staging env or your slackbot messages, you should see this job fail three times. You can look [at this job](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?jobId=5ec57a115735e2ce7ad8f605) to see what a failed build's log should look like in this context. 

Now, in the root dir of your docs-bi-connector fork, remove the invalid toml from your snooty.toml file. Commit and push this change. Now the build should complete successfully (all the files are correctly created) and the parser's error diagnostics are visible in the job's logs.

There is a [wiki on testing makefiles for autobuilder](https://wiki.corp.mongodb.com/display/DE/How+to+test+makefiles+for+the+autobuilder). You can probably use this method with some adjustments for the toml!
