### PR TITLE
Dop 1089

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,11 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for next-gen builds (DOCSP-6545).
+- Support for next-gen builds (DOCSP-6545)
 
-- Integrate snooty parser with autobuilder (DOCSP-6658).
+- Integrate snooty parser with autobuilder (DOCSP-6658)
 
-- Support for baas-docs slack output (DOCSP-6399).
+- Support for baas-docs slack output (DOCSP-6399)
 
 - Support for key generation for machine-created builds (DOCSP-7344)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactored build pipeline to accommodate common build path for deploy and stage (DOCSP-7001).
+- Refactored build pipeline to accommodate common build path for deploy and stage (DOCSP-7001)
 
 ### Fixed
 
@@ -115,11 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for next-gen builds (DOCSP-6545).
+- Support for next-gen builds (DOCSP-6545)
 
-- Integrate snooty parser with autobuilder (DOCSP-6658).
+- Integrate snooty parser with autobuilder (DOCSP-6658)
 
-- Support for baas-docs slack output (DOCSP-6399).
+- Support for baas-docs slack output (DOCSP-6399)
 
 - Support for key generation for machine-created builds (DOCSP-7344)
 
@@ -129,7 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactored build pipeline to accommodate common build path for deploy and stage (DOCSP-7001).
+- Refactored build pipeline to accommodate common build path for deploy and stage (DOCSP-7001)
 
 ### Fixed
 

--- a/worker/jobTypes/githubJob.js
+++ b/worker/jobTypes/githubJob.js
@@ -46,7 +46,7 @@ class GitHubJobClass {
     async applyPatch(patch, currentJobDir) {
         //create patch file
         try {
-          await fs.writeFileSync(`/tmp/myPatch.patch`, patch, { encoding: 'utf8', flag: 'w' });
+          await fs.writeFileSync(`repos/${currentJobDir}/myPatch.patch`, patch, { encoding: 'utf8', flag: 'w' });
           
         } catch (error) {
             console.log("Error creating patch ", error);
@@ -56,7 +56,7 @@ class GitHubJobClass {
         try {
           const commandsToBuild = [
             `cd repos/${currentJobDir}`,
-            `patch -p1 < /tmp/myPatch.patch`
+            `patch -p1 < myPatch.patch`
           ];
             const exec = workerUtils.getExecPromise();
           // return new Promise((resolve, reject) => {

--- a/worker/jobTypes/githubJob.js
+++ b/worker/jobTypes/githubJob.js
@@ -49,8 +49,8 @@ class GitHubJobClass {
           await fs.writeFileSync(`/tmp/myPatch.patch`, patch, { encoding: 'utf8', flag: 'w' });
           
         } catch (error) {
-          console.log("Error creating patch ", error)
-          throw error
+            console.log("Error creating patch ", error);
+            throw error;
         }
         //apply patch
         try {
@@ -60,11 +60,11 @@ class GitHubJobClass {
           ];
             const exec = workerUtils.getExecPromise();
           // return new Promise((resolve, reject) => {
-            const {stdout, stderr} = await exec(commandsToBuild.join(" && "))
+            await exec(commandsToBuild.join(" && "));
     
         } catch (error) {
-          this.dumpError(error);
-          console.log("Error applying patch: ", error)
+            console.log("Error applying patch: ", error);
+            throw error;
         }
     }
 
@@ -83,19 +83,6 @@ class GitHubJobClass {
         }
     }
     
-    async deletePatchFile() {
-        const exec = workerUtils.getExecPromise();
-          return new Promise((resolve, reject) => {
-            exec(`rm /tmp/myPatch.patch`, function(error, stdout, stderr) {
-              if (error !== null) {
-                console.log("exec error: " + error);
-                reject(error);
-              }
-              resolve(true);
-            });
-          });
-    }
-
     // our maintained directory of makefiles
     async downloadMakefile() {
         const makefileLocation = `https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/Makefile.${this.currentJob.payload.repoName}`;
@@ -117,7 +104,6 @@ class GitHubJobClass {
 
     // cleanup before pulling repo
     async cleanup(logger) {
-        const currentJob = this.currentJob;
         logger.save(`${'(rm)'.padEnd(15)}Cleaning up repository`);
         try {
             workerUtils.removeDirectory(`repos/${this.getRepoDirName()}`);
@@ -193,8 +179,7 @@ class GitHubJobClass {
 
             try {
                 const {
-                    stdout,
-                    stderr
+                    stdout
                 } = await exec(commitCheckCommands.join('&&'));
 
                 if (!stdout.includes(`* ${currentJob.payload.branchName}`)) {
@@ -238,10 +223,8 @@ class GitHubJobClass {
         }
 
         try {
-            const {
-                stdout,
-                stderr
-            } = await exec(pullRepoCommands.join(' && '));
+        
+            await exec(pullRepoCommands.join(' && '));
 
         } catch (error) {
             logger.save(
@@ -258,7 +241,6 @@ class GitHubJobClass {
           currentJob.payload.patch,
           this.getRepoDirName(currentJob)
         );
-        await this.deletePatchFile();
       }
         // default commands to run to build repo
         const commandsToBuild = [

--- a/worker/jobTypes/publishDochubJob.js
+++ b/worker/jobTypes/publishDochubJob.js
@@ -4,7 +4,7 @@ const invalidJobDef = new Error('job not valid');
 const invalidEnvironment = new Error(
   'environment variables missing for jobtype'
 );
-const FastlyJob = require('../utils/fastlyJob').FastlyJobClass;
+let FastlyJob = require('../utils/fastlyJob').FastlyJobClass;
 const EnvironmentClass = require('../utils/environment').EnvironmentClass;
 
 //anything that is passed to an exec must be validated or sanitized
@@ -40,11 +40,6 @@ function safePublishDochub(currentJob) {
 async function runPublishDochub(currentJob) {
   workerUtils.logInMongo(currentJob, ' ** Running dochub-fastly migration');
 
-  if (EnvironmentClass.getFastlyToken() === undefined) {
-    workerUtils.logInMongo(currentJob, 'missing env variable: fastly token');
-    throw invalidEnvironment;
-  }
-
   if (
     !currentJob ||
     !currentJob.payload ||
@@ -57,6 +52,11 @@ async function runPublishDochub(currentJob) {
       `${'(DOCHUB)'.padEnd(15)}failed due to insufficient definition`
     );
     throw invalidJobDef;
+  }
+
+  if (EnvironmentClass.getFastlyToken() === undefined) {
+    workerUtils.logInMongo(currentJob, 'missing env variable: fastly token');
+    throw invalidEnvironment;
   }
 
   let map = {

--- a/worker/jobTypes/publishDochubJob.js
+++ b/worker/jobTypes/publishDochubJob.js
@@ -4,7 +4,7 @@ const invalidJobDef = new Error('job not valid');
 const invalidEnvironment = new Error(
   'environment variables missing for jobtype'
 );
-let FastlyJob = require('../utils/fastlyJob').FastlyJobClass;
+const FastlyJob = require('../utils/fastlyJob').FastlyJobClass;
 const EnvironmentClass = require('../utils/environment').EnvironmentClass;
 
 //anything that is passed to an exec must be validated or sanitized

--- a/worker/tests/unit/environment.test.js
+++ b/worker/tests/unit/environment.test.js
@@ -19,7 +19,6 @@ describe('Test Class', () => {
     expect(env.EnvironmentClass.getDB()).toBeDefined();
     expect(env.EnvironmentClass.getDochubMap()).toBeDefined();
     expect(env.EnvironmentClass.getFastlyServiceId()).toBeDefined();
-    expect(env.EnvironmentClass.getFastlyToken()).toBeDefined();
     expect(env.EnvironmentClass.getXlarge()).toBeDefined();
 
   });

--- a/worker/tests/unit/publishDochubJob.unit.test.js
+++ b/worker/tests/unit/publishDochubJob.unit.test.js
@@ -46,7 +46,6 @@ const error = new Error('job not valid');
 describe('Test Class', () => {
   // Dont actually reset the directory and dont care about the logging
   beforeAll(() => {
-    EnvironmentClass.setFastlyToken('test');
     workerUtils.resetDirectory = jest.fn().mockResolvedValue();
     workerUtils.logInMongo = jest.fn().mockResolvedValue();
     jest.useFakeTimers();

--- a/worker/tests/unit/publishDochubJob.unit.test.js
+++ b/worker/tests/unit/publishDochubJob.unit.test.js
@@ -1,5 +1,6 @@
 const job = require('../../jobTypes/publishDochubJob');
 const workerUtils = require('../../utils/utils');
+const EnvironmentClass = require('../../utils/environment').EnvironmentClass;
 
 const payloadObj = {
   source: 'someSource',
@@ -45,16 +46,12 @@ const error = new Error('job not valid');
 describe('Test Class', () => {
   // Dont actually reset the directory and dont care about the logging
   beforeAll(() => {
+    EnvironmentClass.setFastlyToken('test');
     workerUtils.resetDirectory = jest.fn().mockResolvedValue();
     workerUtils.logInMongo = jest.fn().mockResolvedValue();
     jest.useFakeTimers();
   });
 
-  // Tests for dochubpublish() function
-
-  it('runPublishDochub() rejects properly killed', async () => {
-    expect(await job.runPublishDochub(testPayloadGood)).toBeUndefined();
-  });
   // Tests for RunPublishDochub Function
 
   it('runPublishDochub() rejects lack of map', async () => {

--- a/worker/tests/unit/utils.test.js
+++ b/worker/tests/unit/utils.test.js
@@ -6,14 +6,14 @@ const metaObject = {
   repos: [
     {
       name: 'docs-spark-connector',
-      url: 'https://github.com/danielborowski/docs-spark-connector'
+      url: 'https://github.com/mongodb/docs-bi-connector'
     }
   ]
 };
 
 const publishedBranchObject = {
-  repoOwner: 'danielborowski',
-  repoName: 'docs-spark-connector'
+  repoOwner: 'mongodb',
+  repoName: 'docs-bi-connector'
 };
 
 describe('Mongo Tests', () => {

--- a/worker/utils/environment.js
+++ b/worker/utils/environment.js
@@ -28,10 +28,6 @@ class EnvironmentClass {
     return fastlyToken;
   }
 
-  static setFastlyToken(token) {
-    this.fastlyToken = token;
-  }
-
   static getDochubMap() {
     if (dochubMap === undefined) {
       return 'dochubMap';

--- a/worker/utils/environment.js
+++ b/worker/utils/environment.js
@@ -28,6 +28,10 @@ class EnvironmentClass {
     return fastlyToken;
   }
 
+  static setFastlyToken(token) {
+    this.fastlyToken = token;
+  }
+
   static getDochubMap() {
     if (dochubMap === undefined) {
       return 'dochubMap';


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOP-1089

This ticket required making small changes to the autobuilder code in order to accommodate the patch id as part of the build and deploy criteria for the commitless builds feature.

Required changes included:
1. moving the patch file to something local to the repository directory, as the patch file is required by the makefile in order to generate a hash for the patch id at build time
2. removing the delete function so that the patch file remains available for evaluation at build time

While I was there,  I fixed a few small test issues.

To test, run a commitless build against a fork of docs and call the fork docs-stage, then make your fork the upstream. Makefile.docs-stage is where the staged makefile changes that are required are currently living. Run using both the local and commit style builds. https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=100257457 offers a test script, the resulting urls for staging should have collision protection in the form of a hash in the url that corresponds to the patch.