### PR TITLE
new docs makefile

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -102,9 +102,9 @@ deploy-search-index: ## Update the search index for this branch
 	fi
 
 patchapply:
-	echo "GATSBY_SITE=${PROJECT}" > .env.production; \
-	echo "GATSBY_PARSER_USER=${USER}" >> .env.production; \
-	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
+	echo "GATSBY_SITE=${PROJECT}" > .env.production;
+	echo "GATSBY_PARSER_USER=${USER}" >> .env.production;
+	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production;
 	#apply patch id to snooty string if exists
 	if [ -z "${PATCH_ID}" ]; then echo "no patch found"; else  echo "GATSBY_PARSER_PATCHID=${PATCH_ID}" >> .env.production; fi;
 

--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -7,6 +7,7 @@ PRODUCTION_BUCKET=docs-mongodb-org-prod
 PREFIX=docs
 PROJECT=docs
 REPO_DIR=$(shell pwd)
+PATCH_FILE="myPatch.patch"
 
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
@@ -18,6 +19,12 @@ DRIVERS_PATH=source/driver-examples
 
 BLOCKS_FILE=./build/${GIT_BRANCH}/tests.blocks
 TEST_FILE=./build/${GIT_BRANCH}/tests.js
+
+PATCH_ID=$(shell if test -f "${PATCH_FILE}"; then git patch-id < ${PATCH_FILE} | cut -b 1-7; fi)
+
+PATCH_CLAUSE=$(shell if [ ! -z "${PATCH_ID}" ]; then echo "--patchid ${PATCH_ID}"; fi)
+
+URL_APPENDIX=$(shell if [ ! -z "${PATCH_ID}" ]; then echo "_${PATCH_ID}"; fi)
 
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.
@@ -44,9 +51,11 @@ test: html ## Runs test framework over the corpus
 	./build/docs-tools/tools/rst-testing/rst_tester.py ${TEST_FILE}
 
 html: examples ## Builds this branch's HTML under build/<branch>/html
+	if [ ! -z "${PATCH_ID}" ]; then git checkout -b ${GIT_BRANCH}-${PATCH_ID}; fi;
 	giza make html
 	# TEMP copy of video file. Remove once video infrastructure in place.
-	if [ -f source/images/agg-pipeline.mp4 ]; then cp source/images/agg-pipeline.mp4 build/${GIT_BRANCH}/html/_images/; fi 
+	if [ ! -z "${PATCH_ID}" ]; then mkdir -p build/${GIT_BRANCH}${URL_APPENDIX}/html/_images/; fi;
+	if [ -f source/images/agg-pipeline.mp4 ]; then cp source/images/agg-pipeline.mp4 build/${GIT_BRANCH}${URL_APPENDIX}/html/_images/; fi 
 	
 
 publish: examples ## Builds this branch's publishable HTML and other artifacts under build/public
@@ -92,9 +101,16 @@ deploy-search-index: ## Update the search index for this branch
 		mut-index upload build/public/${GIT_BRANCH} -o manual-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${GIT_BRANCH} -s; \
 	fi
 
-next-gen-html: examples
+patchapply:
+	echo "GATSBY_SITE=${PROJECT}" > .env.production; \
+	echo "GATSBY_PARSER_USER=${USER}" >> .env.production; \
+	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
+	#apply patch id to snooty string if exists
+	if [ -z "${PATCH_ID}" ]; then echo "no patch found"; else  echo "GATSBY_PARSER_PATCHID=${PATCH_ID}" >> .env.production; fi;
+
+next-gen-html: examples patchapply
 	# snooty parse and then build-front-end
-	@echo "${SNOOTY_DB_PWD}" | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" || exit 0;
+	@echo "${SNOOTY_DB_PWD}" | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" "${PATCH_CLAUSE}" || exit 0;
 	cp -r "${REPO_DIR}/../../snooty" ${REPO_DIR};
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production; \

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -69,8 +69,8 @@ publish: examples ## Builds this branch's publishable HTML and other artifacts u
 #   <basename>/<filename>.
 #   * Upload each to the S3 bucket under <project>/<username>/<basename>/<filename>
 stage: ## Host online for review
-	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
-	@echo "Hosted at ${STAGING_URL}/${PROJECT}/${USER}/${GIT_BRANCH}/index.html"
+	mut-publish build/${GIT_BRANCH}${URL_APPENDIX}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
+	@echo "Hosted at ${STAGING_URL}/${PROJECT}/${USER}/${GIT_BRANCH}${URL_APPENDIX}/index.html"
 
 # - Enter build/public/<branch>, as well as any symbolic links pointing
 #   to it, and recurse over each file <basename>/<filename>.


### PR DESCRIPTION
These makefile changes enable patch id to be incorporated into builds of branches that have uncommitted/unpushed patches applied.

It enables the use of the commitless staging script with the server docs repository.

This makefile was tested using docs-stage.