### PR TITLE
Dop 1283

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,13 @@ RUN python2 -m pip install python-dateutil
 RUN python -m pip install --upgrade --force pip
 RUN virtualenv /venv
 RUN /venv/bin/pip install --upgrade --force setuptools
-RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
-s/master/giza/requirements.txt
+RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
 
 # helper libraries for docs builds
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/home/docsworker/.local/bin:/usr/local/lib/python2.7/di
-st-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -41,8 +39,7 @@ RUN python3 -m pip install --upgrade pip flit
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \
-	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1)
- && \
+	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1) && \
 	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
 
@@ -50,15 +47,13 @@ RUN git clone https://github.com/mongodb/snooty-parser.git && \
 RUN git clone https://github.com/mongodb/snooty.git snooty
 RUN cd snooty && \
 	git fetch --all && \
-	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && 
-\
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
 	git checkout "$latestTag" && \	
 	npm install --production && \
 	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
 	mkdir -p ./static/images && \
 	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-
-tools/images/bg-accent.svg
+	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
 
 RUN git clone https://github.com/mongodb/devhub.git snooty-devhub
 RUN cd snooty-devhub && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,23 @@ FROM ubuntu:eoan
 # install legacy build environment for docs
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y install libpython2.7-dev python2.7 git python-pip rsync
+RUN apt-get -y install curl
+RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+RUN python2 get-pip.py
 RUN pip install requests virtualenv virtualenvwrapper py-dateutil
 RUN python2 -m pip install python-dateutil 
 RUN python -m pip install --upgrade --force pip
 RUN virtualenv /venv
 RUN /venv/bin/pip install --upgrade --force setuptools
-RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
+RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
+s/master/giza/requirements.txt
 
 # helper libraries for docs builds
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker/.local/bin:/usr/local/lib/python2.7/di
+st-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -29,29 +34,31 @@ RUN npm -g config set user root
 USER docsworker
 
 WORKDIR /home/docsworker
-	
+
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty
 RUN python3 -m pip install --upgrade pip flit
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \
-	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1) && \
+	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1)
+ && \
 	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
-ENV PATH="${PATH}:/home/docsworker/.local/bin"
 
 # install snooty front-end
 RUN git clone https://github.com/mongodb/snooty.git snooty
 RUN cd snooty && \
 	git fetch --all && \
-	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && 
+\
 	git checkout "$latestTag" && \	
 	npm install --production && \
 	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
 	mkdir -p ./static/images && \
 	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
+	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-
+tools/images/bg-accent.svg
 
 RUN git clone https://github.com/mongodb/devhub.git snooty-devhub
 RUN cd snooty-devhub && \

--- a/Dockerfile.xlarge
+++ b/Dockerfile.xlarge
@@ -3,18 +3,23 @@ FROM ubuntu:eoan
 # install legacy build environment for docs
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y install libpython2.7-dev python2.7 git python-pip rsync
+RUN apt-get -y install curl
+RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+RUN python2 get-pip.py
 RUN pip install requests virtualenv virtualenvwrapper py-dateutil
 RUN python2 -m pip install python-dateutil 
 RUN python -m pip install --upgrade --force pip
 RUN virtualenv /venv
 RUN /venv/bin/pip install --upgrade --force setuptools
-RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
+RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
+s/master/giza/requirements.txt
 
 # helper libraries for docs builds
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin:/usr/local/lib/python2.7/di
+st-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -36,22 +41,24 @@ RUN python3 -m pip install --upgrade pip flit
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \
-	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1) && \
+	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1)
+ && \
 	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
-ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin"
 
 # install snooty front-end
 RUN git clone https://github.com/mongodb/snooty.git snooty
 RUN cd snooty && \
 	git fetch --all && \
-	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && 
+\
 	git checkout "$latestTag" && \	
 	npm install --production && \
 	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
 	mkdir -p ./static/images && \
 	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
+	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-
+tools/images/bg-accent.svg
 
 RUN git clone https://github.com/mongodb/devhub.git snooty-devhub
 RUN cd snooty-devhub && \

--- a/Dockerfile.xlarge
+++ b/Dockerfile.xlarge
@@ -11,15 +11,13 @@ RUN python2 -m pip install python-dateutil
 RUN python -m pip install --upgrade --force pip
 RUN virtualenv /venv
 RUN /venv/bin/pip install --upgrade --force setuptools
-RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
-s/master/giza/requirements.txt
+RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
 
 # helper libraries for docs builds
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin:/usr/local/lib/python2.7/di
-st-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -41,8 +39,7 @@ RUN python3 -m pip install --upgrade pip flit
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \
-	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1)
- && \
+	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1) && \
 	git checkout "$latestTag" && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
 
@@ -50,15 +47,13 @@ RUN git clone https://github.com/mongodb/snooty-parser.git && \
 RUN git clone https://github.com/mongodb/snooty.git snooty
 RUN cd snooty && \
 	git fetch --all && \
-	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && 
-\
+	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
 	git checkout "$latestTag" && \	
 	npm install --production && \
 	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
 	mkdir -p ./static/images && \
 	mv ./docs-tools/themes/mongodb/static ./static/docs-tools/ && \
-	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-
-tools/images/bg-accent.svg
+	mv ./docs-tools/themes/guides/static/images/bg-accent.svg ./static/docs-tools/images/bg-accent.svg
 
 RUN git clone https://github.com/mongodb/devhub.git snooty-devhub
 RUN cd snooty-devhub && \


### PR DESCRIPTION
This is a dockerfile change related to DOP-1283: Upgrade dockerfile.

https://jira.mongodb.org/browse/DOP-1283

In this PR I have upgraded the OS to the latest stable linux release, as well as added some manual installations for pip, which has fallen out of support with python2.

Once this is merged to stage, we will attempt a build in the staging env.

I'm fairly certain I may have a superfluous pip install call in there, if you find it, let me know. Otherwise, proof is in the staged pudding.