### PR TITLE
add publish command for legacy builds

### DIFF
--- a/worker/jobTypes/S3Publish.js
+++ b/worker/jobTypes/S3Publish.js
@@ -2,32 +2,29 @@ const fs = require('fs-extra');
 const workerUtils = require('../utils/utils');
 const FastlyJob = require('../utils/fastlyJob').FastlyJobClass;
 
-
 class S3PublishClass {
-  constructor(GitHubJob) {
+  constructor (GitHubJob) {
     this.fastly = new FastlyJob(GitHubJob);
     this.GitHubJob = GitHubJob;
     fs.pathExists();
   }
 
-  async pushToStage(logger) {
+  async pushToStage (logger) {
     logger.save(`${'(stage)'.padEnd(15)}Setting up push to staging function`);
     const stageCommands = [
       '. /venv/bin/activate',
       `cd repos/${this.GitHubJob.getRepoDirName()}`,
-      'make stage',
+      'make stage'
     ];
 
     // check if need to build next-gen
     if (this.GitHubJob.buildNextGen()) {
-      if(this.GitHubJob.currentJob.payload.pathPrefix){
+      if (this.GitHubJob.currentJob.payload.pathPrefix) {
         stageCommands[stageCommands.length - 1] = `make next-gen-stage ${this.GitHubJob.currentJob.payload.mutPrefix}`;
+      } else {
+        // front end constructs path prefix for regular githubpush jobs and commitless staging jobs
+        stageCommands[stageCommands.length - 1] = 'make next-gen-stage'
       }
-      //front end constructs path prefix for regular githubpush jobs and commitless staging jobs
-      else{
-        stageCommands[stageCommands.length - 1] = `make next-gen-stage`
-      }
-
     }
 
     logger.save(`${'(stage)'.padEnd(15)}Pushing to staging`);
@@ -36,31 +33,31 @@ class S3PublishClass {
       const command = stageCommands.join(' && ');
       const { stdout, stderr } = await exec(command);
       let stdoutMod = stdout;
-      logger.save(
-        `${'(stage)'.padEnd(15)}Staging stderr details:\n\n${stderr}`
-      );
+
+      if (stderr && stderr.indexOf('ERROR') !== -1) {
+        logger.save(
+          `${'(stage)'.padEnd(15)}Failed to push to staging`
+        );
+        throw new Error(`Failed pushing to staging: ${stderr}`)
+      }
       // get only last part of message which includes # of files changes + s3 link
       if (stdout.indexOf('Summary') !== -1) {
         stdoutMod = stdout.substr(stdout.indexOf('Summary'));
       }
       return new Promise((resolve) => {
         logger.save(`${'(stage)'.padEnd(15)}Finished pushing to staging`);
-        logger.save(
-          `${'(stage)'.padEnd(15)}Staging push details:\n\n${stdoutMod}`
-        );
         resolve({
           status: 'success',
-          stdout: stdoutMod,
+          stdout: stdoutMod
         });
       });
     } catch (errResult) {
       logger.save(`${'(stage)'.padEnd(15)}stdErr: ${errResult.stderr}`);
       throw errResult;
-
     }
   }
 
-  async pushToProduction(logger) {
+  async pushToProduction (logger) {
     logger.save(`${'(prod)'.padEnd(15)}Pushing to production`);
 
     // this is the final command to deploy
@@ -68,7 +65,7 @@ class S3PublishClass {
     const deployCommands = [
       '. /venv/bin/activate',
       `cd repos/${this.GitHubJob.getRepoDirName()}`,
-      'make deploy',
+      'make deploy'
     ];
 
     // check if need to build next-gen
@@ -80,9 +77,15 @@ class S3PublishClass {
     try {
       const exec = workerUtils.getExecPromise();
       const command = deployCommands.join(' && ');
-      const { stdout } = await exec(command);
+      const { stdout, stderr } = await exec(command);
       let stdoutMod = stdout;
-      
+
+      if (stderr && stderr.indexOf('ERROR') !== -1) {
+        logger.save(
+          `${'(stage)'.padEnd(15)}Failed to push to staging`
+        );
+        throw new Error(`Failed pushing to staging: ${stderr}`)
+      }
       // check for json string output from mut
       const validateJsonOutput = stdout ? stdout.substr(0, stdout.lastIndexOf(']}') + 2) : '';
 
@@ -91,9 +94,9 @@ class S3PublishClass {
         const stdoutJSON = JSON.parse(validateJsonOutput);
         const urls = stdoutJSON.urls;
         // pass in urls to fastly function to purge cache
-        this.fastly.purgeCache(urls).then(function(data) {
+        this.fastly.purgeCache(urls).then(function (data) {
           logger.save(`${'(prod)'.padEnd(15)}Fastly finished purging URL's`);
-          logger.sendSlackMsg(`Fastly Summary: The following pages were purged from cache for your deploy`);
+          logger.sendSlackMsg('Fastly Summary: The following pages were purged from cache for your deploy');
           // when finished purging
           // batch urls to send as single slack message
           let batchedUrls = [];
@@ -109,7 +112,7 @@ class S3PublishClass {
             }
           }
         });
-      } catch(e) {
+      } catch (e) {
         // if not JSON, then it's a normal string output from mut
         // get only last part of message which includes # of files changes + s3 link
         if (stdout.indexOf('Summary') !== -1) {
@@ -119,12 +122,9 @@ class S3PublishClass {
 
       return new Promise((resolve) => {
         logger.save(`${'(prod)'.padEnd(15)}Finished pushing to production`);
-        logger.save(
-          `${'(prod)'.padEnd(15)}Production deploy details:\n\n${stdoutMod}`
-        );
         resolve({
           status: 'success',
-          stdout: stdoutMod,
+          stdout: stdoutMod
         });
       });
     } catch (errResult) {
@@ -135,5 +135,5 @@ class S3PublishClass {
 }
 
 module.exports = {
-  S3PublishClass,
+  S3PublishClass
 };

--- a/worker/jobTypes/S3Publish.js
+++ b/worker/jobTypes/S3Publish.js
@@ -46,6 +46,9 @@ class S3PublishClass {
       }
       return new Promise((resolve) => {
         logger.save(`${'(stage)'.padEnd(15)}Finished pushing to staging`);
+        logger.save(
+          `${'(stage)'.padEnd(15)}Staging push details:\n\n${stdoutMod}`
+        );
         resolve({
           status: 'success',
           stdout: stdoutMod

--- a/worker/jobTypes/S3Publish.js
+++ b/worker/jobTypes/S3Publish.js
@@ -85,9 +85,9 @@ class S3PublishClass {
 
       if (stderr && stderr.indexOf('ERROR') !== -1) {
         logger.save(
-          `${'(stage)'.padEnd(15)}Failed to push to staging`
+          `${'(prod)'.padEnd(15)}Failed to push to prod`
         );
-        throw new Error(`Failed pushing to staging: ${stderr}`)
+        throw new Error(`Failed pushing to prod: ${stderr}`)
       }
       // check for json string output from mut
       const validateJsonOutput = stdout ? stdout.substr(0, stdout.lastIndexOf(']}') + 2) : '';
@@ -125,6 +125,9 @@ class S3PublishClass {
 
       return new Promise((resolve) => {
         logger.save(`${'(prod)'.padEnd(15)}Finished pushing to production`);
+        logger.save(
+          `${'(prod)'.padEnd(15)}Deploy details:\n\n${stdoutMod}`
+        );
         resolve({
           status: 'success',
           stdout: stdoutMod

--- a/worker/jobTypes/S3Publish.js
+++ b/worker/jobTypes/S3Publish.js
@@ -68,7 +68,7 @@ class S3PublishClass {
     const deployCommands = [
       '. /venv/bin/activate',
       `cd repos/${this.GitHubJob.getRepoDirName()}`,
-      'make deploy'
+      'make publish && make deploy'
     ];
 
     // check if need to build next-gen

--- a/worker/jobTypes/productionDeployJob.js
+++ b/worker/jobTypes/productionDeployJob.js
@@ -8,7 +8,7 @@ const Logger = require('../utils/logger').LoggerClass;
 const buildTimeout = 60 * 450;
 const invalidJobDef = new Error('job not valid');
 
-async function verifyUserEntitlements(currentJob) {
+async function verifyUserEntitlements (currentJob) {
   const user = currentJob.user;
   const entitlementsObject = await workerUtils.getUserEntitlements(user);
   const repoOwner = currentJob.payload.repoOwner;
@@ -20,9 +20,9 @@ async function verifyUserEntitlements(currentJob) {
   return false;
 }
 
-async function verifyBranchConfiguredForPublish(currentJob) {
+async function verifyBranchConfiguredForPublish (currentJob) {
   const repoObject = {
-    repoOwner: currentJob.payload.repoOwner, repoName: currentJob.payload.repoName,
+    repoOwner: currentJob.payload.repoOwner, repoName: currentJob.payload.repoName
   };
   const repoContent = await workerUtils.getRepoPublishedBranches(repoObject);
   if (repoContent && repoContent.status === 'success') {
@@ -34,20 +34,20 @@ async function verifyBranchConfiguredForPublish(currentJob) {
 
 // anything that is passed to an exec must be validated or sanitized
 // we use the term sanitize here lightly -- in this instance this // ////validates
-function safeString(stringToCheck) {
+function safeString (stringToCheck) {
   return (
     validator.isAscii(stringToCheck) &&
     validator.matches(stringToCheck, /^((\w)*[-.]?(\w)*)*$/)
   );
 }
 
-function safeGithubProdPush(currentJob) {
+function safeGithubProdPush (currentJob) {
   if (
-    !currentJob
-    || !currentJob.payload
-    || !currentJob.payload.repoName
-    || !currentJob.payload.repoOwner
-    || !currentJob.payload.branchName
+    !currentJob ||
+    !currentJob.payload ||
+    !currentJob.payload.repoName ||
+    !currentJob.payload.repoOwner ||
+    !currentJob.payload.branchName
   ) {
     workerUtils.logInMongo(
       currentJob,
@@ -66,30 +66,29 @@ function safeGithubProdPush(currentJob) {
   throw invalidJobDef;
 }
 
-async function startGithubBuild(job, logger) {
+async function startGithubBuild (job, logger) {
   const builder = new GatsbyAdapter(job);
   const buildOutput = await workerUtils.promiseTimeoutS(
     buildTimeout,
     job.buildRepo(logger, builder, true),
-    'Timed out on build',
+    'Timed out on build'
   );
-  // checkout output of build
+    // checkout output of build
   if (buildOutput && buildOutput.status === 'success') {
     // only post entire build output to slack if there are warnings
     const buildOutputToSlack = `${buildOutput.stdout}\n\n${buildOutput.stderr}`;
-    if (buildOutputToSlack.indexOf('WARNING') !== -1) {
-      await logger.sendSlackMsg(buildOutputToSlack);
-    }
+    logger.filterOutputForUserLogs(buildOutputToSlack, job);
     return new Promise((resolve) => {
       resolve(true);
     });
   }
-  return new Promise((reject) => {
+
+  return new Promise((resolve, reject) => {
     reject(false);
   });
 }
 
-async function pushToProduction(publisher, logger) {
+async function pushToProduction (publisher, logger) {
   const prodOutput = await workerUtils.promiseTimeoutS(
     buildTimeout,
     publisher.pushToProduction(logger),
@@ -103,12 +102,12 @@ async function pushToProduction(publisher, logger) {
       resolve(true);
     });
   }
-  return new Promise((reject) => {
+  return new Promise((resolve, reject) => {
     reject(false);
   });
 }
 
-async function runGithubProdPush(currentJob) {
+async function runGithubProdPush (currentJob) {
   const ispublishable = await verifyBranchConfiguredForPublish(currentJob);
   const userIsEntitled = await verifyUserEntitlements(currentJob);
 
@@ -124,10 +123,10 @@ async function runGithubProdPush(currentJob) {
   workerUtils.logInMongo(currentJob, ' ** Running github push function');
 
   if (
-    !currentJob
-    || !currentJob.payload
-    || !currentJob.payload.repoName
-    || !currentJob.payload.branchName
+    !currentJob ||
+    !currentJob.payload ||
+    !currentJob.payload.repoName ||
+    !currentJob.payload.branchName
   ) {
     workerUtils.logInMongo(currentJob, `${'(BUILD)'.padEnd(15)}failed due to insufficient definition`);
     throw invalidJobDef;
@@ -143,17 +142,17 @@ async function runGithubProdPush(currentJob) {
   await pushToProduction(publisher, logger);
 
   const files = workerUtils.getFilesInDir(
-    `./${currentJob.payload.repoName}/build/public`,
+    `./${currentJob.payload.repoName}/build/public`
   );
 
   return files;
 }
 
 module.exports = {
-	startGithubBuild,
+  startGithubBuild,
   runGithubProdPush,
   safeGithubProdPush,
   verifyBranchConfiguredForPublish,
   verifyUserEntitlements,
-	pushToProduction,
+  pushToProduction
 };


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOP-1238 introduced a regression for legacy builds -- that we didn't catch because we never tested legacy deploys in any of our testing. 

this [job](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?jobId=5f46aa172e8d3a887d55db55) successfully updated docs-realm:

- the realm PR: https://github.com/mongodb/docs-realm/pull/582 and (one of the) corresponding changed page https://docs.mongodb.com/realm/dotnet/


I am going to squash all the commits into one when we merge (I squashed locally but then when I tried to push the changes, it complained I didn't have updates from the remote...bc ya know, I squashed after having already pushed. Mondays!)