### PR TITLE
Fix realm search index URL

### DIFF
--- a/makefiles/Makefile.docs-realm
+++ b/makefiles/Makefile.docs-realm
@@ -79,4 +79,4 @@ deploy: build/public ## Deploy to the production bucket
 
 deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
-	mut-index upload build/public -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL} -s
+	mut-index upload build/public -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/realm -s


### PR DESCRIPTION
We're going to need to apply something similar to many other makefiles I believe, but we *need* to change how the prefix is passed in for this to not be really weird