### PR TITLE
DOP-1681: updates cloud-docs-osb makefile for modernity & testing

### DIFF
--- a/makefiles/Makefile.cloud-docs-osb-test
+++ b/makefiles/Makefile.cloud-docs-osb-test
@@ -1,14 +1,11 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-ifeq ($(STAGING_USERNAME),)
-	USER=$(shell whoami)
-else
-	USER=$(STAGING_USERNAME)
-endif
+USER=$(shell whoami)
 STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
 PRODUCTION_URL="https://docs.mongodb.com"
 STAGING_BUCKET=docs-mongodb-org-staging
 PRODUCTION_BUCKET=docs-atlas-osb-prod
 PROJECT=atlas-open-service-broker
+# PREFIX=atlas-open-service-broker -> doesn't seem to be used anywhere
 REPO_DIR=$(shell pwd)
 COMMIT_HASH=$(shell git rev-parse --short HEAD)
 
@@ -30,33 +27,18 @@ help:
 
 #################################################################
 ####                                                         ####
-####             BUILD DOCUMENTATION ARTIFACTS               ####
+####             LEGACY MAKE TARGETS                         ####
 ####                                                         ####
-#################################################################
-
-
-#################################################################
-####                  BUILD STAGING ARTIFACTS                ####
 #################################################################
 
 ## Builds this branch's HTML under build/<branch>/html
 html:
 	time giza make html
 
-
-#################################################################
-####       BUILD STAGING ARTIFACTS TO CLEAN DIRECTORY        ####
-#################################################################
-
 ## Build this branch's HTML files to a fresh build directory
 clean-html:
 	rm -rf build/${GIT_BRANCH}
 	time giza make html
-
-
-#################################################################
-####                 BUILD PRODUCTION ARTIFACTS              ####
-#################################################################
 
 ## Builds this branch's publishable HTML and other artifacts under
 ## build/public
@@ -64,27 +46,10 @@ publish:
 	giza make publish
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi
 
-
-#################################################################
-####                                                         ####
-####        DEPLOY KUBERNETES OPERATOR DOCUMENTATION         ####
-####                                                         ####
-#################################################################
-
-
-#################################################################
-####   DEPLOY KUBERNETES OPERATOR DOCUMENTATION TO STAGING   ####
-#################################################################
-
 ## Host online for review
 stage:
 	mut-publish build/${GIT_BRANCH}/html ${STAGING_BUCKET} --prefix=${PROJECT} --stage ${ARGS}
 	@echo "\n\nHosted at ${STAGING_URL}/${PROJECT}/${USER}/${GIT_BRANCH}/index.html"
-
-
-#################################################################
-####  DEPLOY KUBERNETES OPERATOR DOCUMENTATION TO PRODUCTION ####
-#################################################################
 
 ## Deploy to the production bucket
 deploy: build/public
@@ -94,23 +59,31 @@ deploy: build/public
 
 	$(MAKE) deploy-search-index
 
+#################################################################
+####                                                         ####
+####             SNOOTY MAKE TARGETS                         ####
+####                                                         ####
+#################################################################
+
 ## Update the search index for this branch
 deploy-search-index:
 	@echo "Building search index"
-	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-current.json --aliases ${PROJECT}-${GIT_BRANCH} -u ${PRODUCTION_URL}/${PROJECT}/stable -g -s; \
-	else \
-		mut-index upload build/public/${GIT_BRANCH} -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL}/${PROJECT}/${GIT_BRANCH} -s; \
-	fi
+	mut-index upload public -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL} -s
+
 
 next-gen-html:
 	# snooty parse and then build-front-end
-	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" || exit 0;
-	cp -r ${REPO_DIR}/../../snooty ${REPO_DIR};
+	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
+	if [ $$? -eq 1]; then |
+		exit 1;\
+   else \
+      exit 0; \
+   fi
+
+   rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
+	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production; \
-	echo "GATSBY_PARSER_USER=${USER}" >> .env.production; \
-	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
@@ -118,3 +91,11 @@ next-gen-html:
 next-gen-stage: ## Host online for review
 	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${PROJECT}" --stage ${ARGS}
 	@echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${PROJECT}/${USER}/${GIT_BRANCH}/"
+
+next-gen-deploy:
+	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
+	@yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="$(filter-out $@,$(MAKECMDGOALS))" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
+	@echo "Hosted at ${PRODUCTION_URL}/$(filter-out $@,$(MAKECMDGOALS))/index.html";
+	$(MAKE) next-gen-deploy-search-index
+%:
+	@:

--- a/makefiles/Makefile.cloud-docs-osb-test
+++ b/makefiles/Makefile.cloud-docs-osb-test
@@ -76,11 +76,11 @@ next-gen-html:
 	@-echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
 	if [ $$? -eq 1]; then |
 		exit 1;\
-   else \
-      exit 0; \
-   fi
+			else \
+				exit 0; \
+			fi
 
-   rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
+	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR};
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production; \


### PR DESCRIPTION
Note: cloud-docs-osb is not present versioned - there's only one published branch, so we don't need the published branches stuff.

I put in the PREFIX line because it was in the docs-ecosystem Makefile, but then commented it out since it didn't seem to be used anywhere and I wasn't sure what was going on there.