### PR TITLE
Please review each record that pertains to a repo that you oversee

### DIFF
--- a/repos_branches.json
+++ b/repos_branches.json
@@ -259,7 +259,7 @@
       "publishOriginalBranchName": true,
       "active": true,
       "aliases": [
-        "v1.9",
+        "v1.10",
         "upcoming"
       ]
     },

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -259,6 +259,59 @@
       "aliases": [
         "stable"
       ]
+        {
+      "name": "v1.8",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.7",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.6",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.5",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.4.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.3.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.2.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.1.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.0.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
     }
   ]
 },{

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -181,42 +181,6 @@
       "publishOriginalBranchName": true,
       "active": true,
       "aliases": null
-    },
-    {
-      "name": "v1.1",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
-    },
-    {
-      "name": "v0.12",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
-    },
-    {
-      "name": "v0.11",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
-    },
-    {
-      "name": "v0.10",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
-    },
-    {
-      "name": "v0.9",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
-    },
-    {
-      "name": "v0.8",
-      "publishOriginalBranchName": true,
-      "active": true,
-      "aliases": null
     }
   ]
 },{

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -144,7 +144,10 @@
       "name": "master",
       "publishOriginalBranchName": true,
       "active": true,
-      "aliases": null
+      "aliases": [
+        "v1.9",
+        "upcoming"
+      ]
     },
     {
       "name": "v1.8",

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -147,6 +147,14 @@
       "aliases": null
     },
     {
+      "name": "v1.8",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "current"
+      ]
+    },
+    {
       "name": "v1.7",
       "publishOriginalBranchName": true,
       "active": true,

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -1,0 +1,475 @@
+[{
+  "_id": {
+    "$oid": "5f6aacb082989d521a606362"
+  },
+  "repoName": "devhub-content",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchname": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aad1682989d521a606363"
+  },
+  "repoName": "docs-bi-connector",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.13",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.12",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.11",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.10",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.14",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aad5982989d521a606364"
+  },
+  "repoName": "docs-charts",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "saas",
+        "atlas"
+      ]
+    },
+    {
+      "name": "19.12",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": [
+        "current",
+        "onprem"
+      ]
+    },
+    {
+      "name": "19.09",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aad7d82989d521a606365"
+  },
+  "repoName": "docs-compass",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "current"
+      ]
+    },
+    {
+      "name": "beta",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "upcoming"
+      ]
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aada982989d521a606366"
+  },
+  "repoName": "docs-datalake",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aadd682989d521a606367"
+  },
+  "repoName": "docs-ecosystem",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aae3882989d521a606368"
+  },
+  "repoName": "docs-k8s-operator",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.7",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.6",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.5",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.4",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.3",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.2",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.1",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v0.12",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v0.11",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v0.10",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v0.9",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v0.8",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aae9a82989d521a606369"
+  },
+  "repoName": "docs-kafka-connector",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "upcoming"
+      ]
+    },
+    {
+      "name": "v1.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.3",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "current"
+      ]
+    },
+    {
+      "name": "v1.1",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.2",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaeb682989d521a60636a"
+  },
+  "repoName": "docs-landing",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaed282989d521a60636b"
+  },
+  "repoName": "docs-mongocli",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "v1.9",
+        "upcoming"
+      ]
+    },
+    {
+      "name": "v1.8",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": [
+        "stable"
+      ]
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaef082989d521a60636c"
+  },
+  "repoName": "docs-mongodb-shell",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaf0982989d521a60636d"
+  },
+  "repoName": "docs-mongodb-vscode",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaf2282989d521a60636e"
+  },
+  "repoName": "docs-node",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaf3782989d521a60636f"
+  },
+  "repoName": "docs-realm",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": "false",
+      "active": "true",
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaf5182989d521a606370"
+  },
+  "repoName": "docs-spark-connector",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.4",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.3",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.2",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.1",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v2.0",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    },
+    {
+      "name": "v1.1",
+      "publishOriginalBranchName": true,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f6aaf7e82989d521a606371"
+  },
+  "repoName": "govcloud-docs",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": [
+        "main"
+      ]
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5f870214491122f44f440836"
+  },
+  "repoName": "docs-testing",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchname": false,
+      "active": true,
+      "aliases": [
+        "current",
+        "saas",
+        "atlas"
+      ]
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5faaed879505771886986df6"
+  },
+  "repoName": "cloud-docs-osb",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchName": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5fab0f63a35f4303e2b5c06c"
+  },
+  "repoName": "docs-tutorials",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchname": false,
+      "active": true,
+      "aliases": null
+    }
+  ]
+},{
+  "_id": {
+    "$oid": "5fac1ce373a72fca02ec90c5"
+  },
+  "repoName": "docs",
+  "branches": [
+    {
+      "name": "master",
+      "publishOriginalBranchname": false,
+      "active": true,
+      "aliases": [
+        "manual",
+        "v4.4"
+      ]
+    }
+  ]
+}]

--- a/repos_branches.json
+++ b/repos_branches.json
@@ -264,7 +264,7 @@
       ]
     },
     {
-      "name": "v1.8",
+      "name": "v1.9",
       "publishOriginalBranchName": true,
       "active": true,
       "aliases": [


### PR DESCRIPTION
We use an atlas collection to both populate the options in the dropdown menu of the /deploy app, and to correctly enter fields in the job document that the autobuilder picks up. **To support alias publishing, we have to update this collection. This PR contains all the changes to this collection.**

Eventually, a slack app will be created for adding/updating aliases. In the meantime, we are providing these docs so docs-leads can understand the data model for this collection (** eventually I will publish this info in a wiki, after Thanksgiving). 

Overall, the new data model looks like this:

```
repoName: string 
branches: array (of objects)
[
    {
      Name: string
      publishOriginalBranchName: boolean 
      active: boolean 
      aliases: null or array
    },
   Obj2, 
   Obj3 
]

```

**We need an entry for every repo that we publish on the autobuilder.** As this project has spanned many sprints, and we have been rapidly moving more projects onto the autobuilder, **I may have missed some repos. Please use this PR to correct my work.**

We have versioned and non-versioned repos, both of which can be aliased. 

To correctly publish each site (w/ or w/o aliases), we have to consider four things: 

1. Are we publishing the original branch name in addition to the branch's aliases? ie we are publishing docs.mongodb.com/charts/master along with /saas and /atlas
- For aliased repos, if you want to publish the orig branch name, you must have the "publishOriginalBranchName" field set to true
- Non-versioned and non-aliased repos (such as devhub, docs-realm, docs-ecosystem) must have the "publishOriginalBranchName" field set to false (we have never had /master in the url for these sites)

2. What (if any) are the aliases for this branch? You can also think of this question as, "When I deploy X github branch, what do I want the suffix of the url to be?"  For the master branch for docs-charts, the aliases are saas and atlas.
- For a branch with no aliases, the "aliases" field must be of type null 

3. Which is the primary alias? 
- The primary alias is the one which will trigger reindexing the repo for global search. Traditionally, we reindexed the stable branch (defined by the stableBranch field in the published branch files on docs-tools) for global search. Now that the stable branch may have multiple aliases, we put the primary alias as the first entry in the array of the aliases field.

4. Is every publishable branch represented? There should be an object for every publishable branch for a given repo document.