### PR TITLE
make dockerfile xlarge the default dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /home/docsworker-xlarge
 
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty
-RUN python3 -m pip install --upgrade pip flit
+RUN python3 -m pip install pip==20.2 flit==3.0.0
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/home/docsworker/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -27,11 +27,11 @@ RUN apt-get install --yes nodejs
 RUN apt-get install --yes build-essential
 
 # setup user and root directory
-RUN useradd -ms /bin/bash docsworker
+RUN useradd -ms /bin/bash docsworker-xlarge
 RUN npm -g config set user root
-USER docsworker
+USER docsworker-xlarge
 
-WORKDIR /home/docsworker
+WORKDIR /home/docsworker-xlarge
 
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty
@@ -39,16 +39,14 @@ RUN python3 -m pip install --upgrade pip flit
 RUN git clone https://github.com/mongodb/snooty-parser.git && \
 	cd snooty-parser && \
 	git fetch --tags && \
-	latestTag=$(git describe --tags `git tag --sort=-v:refname` | head -n 1) && \
-	git checkout "$latestTag" && \
+	git checkout <TAG> && \
 	FLIT_ROOT_INSTALL=1 python3 -m flit install
 
 # install snooty front-end
 RUN git clone https://github.com/mongodb/snooty.git snooty
 RUN cd snooty && \
 	git fetch --all && \
-	latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) && \
-	git checkout "$latestTag" && \	
+	git checkout <TAG> && \	
 	npm install --production && \
 	git clone https://github.com/mongodb/docs-tools.git docs-tools && \
 	mkdir -p ./static/images && \

--- a/Dockerfile.nonxlarge
+++ b/Dockerfile.nonxlarge
@@ -17,7 +17,7 @@ RUN /venv/bin/pip install -r https://raw.githubusercontent.com/mongodb/docs-tool
 RUN apt-get update && apt-get install -y python3 python3-dev python3-pip
 RUN apt-get -y install git pkg-config libxml2-dev
 RUN python3 -m pip install mut
-ENV PATH="${PATH}:/home/docsworker-xlarge/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
+ENV PATH="${PATH}:/home/docsworker/.local/bin:/usr/local/lib/python2.7/dist-packages/virtualenv/bin"
 
 # get node 12
 # https://gist.github.com/RinatMullayanov/89687a102e696b1d4cab
@@ -27,11 +27,11 @@ RUN apt-get install --yes nodejs
 RUN apt-get install --yes build-essential
 
 # setup user and root directory
-RUN useradd -ms /bin/bash docsworker-xlarge
+RUN useradd -ms /bin/bash docsworker
 RUN npm -g config set user root
-USER docsworker-xlarge
+USER docsworker
 
-WORKDIR /home/docsworker-xlarge
+WORKDIR /home/docsworker
 
 # install snooty parser
 RUN python3 -m pip uninstall -y snooty


### PR DESCRIPTION
make the xlarge version the default dockerfile we use - also remove the latestTag var, forcing us to specify the tags we want to use (otherwise building docker will crash).