### PR TITLE
DOP-1913: add get-build-dependencies to cloud-docs-osb makefile

### DIFF
--- a/makefiles/Makefile.cloud-docs-osb
+++ b/makefiles/Makefile.cloud-docs-osb
@@ -13,6 +13,8 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+get-build-dependencies:
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/cloud-docs-osb.yaml > ${REPO_DIR}/published-branches.yaml
 
 next-gen-html:
 	# snooty parse and then build-front-end


### PR DESCRIPTION
Attempts to deploy cloud-docs-osb fail on the following:

```
{
    time: "Thursday, January 21, 2021, 14:34:38 UTC",
    reason: "Error: Command failed: . /venv/bin/activate && cd repos/cloud-docs-osb && rm -f makefile && make get-build-dependencies && make next-gen-html
    make: *** No rule to make target 'get-build-dependencies'.  Stop.
    "
}
```
This should solve that issue.