### PR TITLE
Makefile side changes for DOP-1915, DOP-1858, DOP-1812 + Beginning shared makefile

### DIFF
--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -19,6 +19,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 .PHONY: help stage fake-deploy deploy publish deploy-search-index remote-includes next-gen-html
 
 help:
@@ -54,13 +56,9 @@ next-gen-stage: ## Host online for review
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	@yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-	$(MAKE) next-gen-deploy-search-index
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.cloud-docs-osb
+++ b/makefiles/Makefile.cloud-docs-osb
@@ -20,6 +20,8 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/cloud-docs-osb.yaml > ${REPO_DIR}/published-branches.yaml
 
@@ -47,10 +49,6 @@ next-gen-stage: ## Host online for review
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	@yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-	$(MAKE) next-gen-deploy-search-index
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.cloud-docs-stage
+++ b/makefiles/Makefile.cloud-docs-stage
@@ -18,6 +18,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 .PHONY: help stage fake-deploy deploy publish deploy-search-index remote-includes next-gen-html
 
 help:
@@ -118,10 +120,6 @@ deploy: build/public
 
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
 
 
 ##########################################################

--- a/makefiles/Makefile.devhub
+++ b/makefiles/Makefile.devhub
@@ -21,6 +21,8 @@ GITHUB_PASS = $(shell printenv GITHUB_BOT_PASSWORD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 .PHONY: examples help html publish stage deploy deploy-search-index
 
 

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -11,7 +11,6 @@ PRODUCTION_URL=https://developer.mongodb.com
 
 PROJECT=devhub
 MUT_PREFIX ?= $(PROJECT)
-PREFIX=devhub
 REPO_DIR=$(shell pwd)
 
 COMMIT_HASH=$(shell git rev-parse --short HEAD)
@@ -20,6 +19,8 @@ GITHUB_USER = $(shell printenv GITHUB_BOT_USERNAME)
 GITHUB_PASS = $(shell printenv GITHUB_BOT_PASSWORD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
 
 update-snooty:
 	cd ../../snooty-devhub; \

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -21,6 +21,8 @@ GITHUB_PASS = $(shell printenv GITHUB_BOT_PASSWORD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 .PHONY: examples help html publish stage deploy deploy-search-index
 
 update-snooty:

--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -22,6 +22,8 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 # "PROJECT" currently exists to support having multiple projects
 # within one bucket. For the manual it is empty.
 
@@ -113,10 +115,6 @@ deploy: build/public ## Deploy to the production bucket
 
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
 
 next-gen-deploy:	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};

--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -20,7 +20,9 @@ export DIAGNOSTICS_FORMAT=JSON
 
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
- 
+
+include ~/shared.mk
+
 next-gen-html: get-build-dependencies
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
@@ -47,13 +49,9 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
 	
 redirects:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi

--- a/makefiles/Makefile.docs-charts
+++ b/makefiles/Makefile.docs-charts
@@ -21,6 +21,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
@@ -47,9 +49,5 @@ next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix="${PRODUCTION_URL}" --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
-	$(MAKE) next-gen-deploy-search-index
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-commandline-tools
+++ b/makefiles/Makefile.docs-commandline-tools
@@ -23,7 +23,9 @@ REPO_DIR=$(shell pwd)
 
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
-	
+
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
@@ -50,7 +52,7 @@ get-build-dependencies:
 	
 next-gen-deploy:	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
 next-gen-deploy-search-index: ## Update the search index for this branch

--- a/makefiles/Makefile.docs-compass
+++ b/makefiles/Makefile.docs-compass
@@ -1,9 +1,7 @@
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 STAGING_URL="https://docs-mongodbcom-staging.corp.mongodb.com"
-PRODUCTION_URL="https://docs.mongodb.com"
 STAGING_BUCKET=docs-mongodb-org-staging
-PRODUCTION_BUCKET=docs-compass-prod
 
 ifeq ($(SNOOTY_INTEGRATION),false)
   PRODUCTION_URL="https://docs.mongodb.com"
@@ -18,9 +16,10 @@ PROJECT=compass
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
-
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
 
 next-gen-html: get-build-dependencies
 	# snooty parse and then build-front-end
@@ -41,10 +40,6 @@ next-gen-stage: ## Host online for review
 	mut-publish public ${STAGING_BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS};
 	echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-compass.yaml > ${REPO_DIR}/published-branches.yaml
@@ -52,5 +47,5 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-	$(MAKE) next-gen-deploy-search-index
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi

--- a/makefiles/Makefile.docs-datalake
+++ b/makefiles/Makefile.docs-datalake
@@ -23,6 +23,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 # "PATCH_ID" related shell commands to manage commitless builds
 PATCH_FILE="myPatch.patch"
 
@@ -31,6 +33,8 @@ PATCH_ID=$(shell if test -f "${PATCH_FILE}"; then git patch-id < ${PATCH_FILE} |
 PATCH_CLAUSE=$(shell if [ ! -z "${PATCH_ID}" ]; then echo --patch "${PATCH_ID}"; fi)
 
 URL_APPENDIX=$(shell if [ ! -z "${PATCH_ID}" ]; then echo "_${PATCH_ID}"; fi)
+
+
 
 next-gen-html:
 	# snooty parse and then build-front-end
@@ -82,10 +86,5 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-	$(MAKE) next-gen-deploy-search-index
-
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi

--- a/makefiles/Makefile.docs-ecosystem
+++ b/makefiles/Makefile.docs-ecosystem
@@ -24,6 +24,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 assets: ## pulls assets from the docs-assets
 	rm -rf source/figures docs-assets
 	mkdir source/figures
@@ -56,10 +58,6 @@ get-build-dependencies: assets
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-java
+++ b/makefiles/Makefile.docs-java
@@ -22,6 +22,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
@@ -48,10 +50,6 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-k8s-operator
+++ b/makefiles/Makefile.docs-k8s-operator
@@ -24,6 +24,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.
 STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
@@ -107,7 +109,7 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
 
@@ -127,8 +129,3 @@ deploy: build/public
 
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-kafka-connector
+++ b/makefiles/Makefile.docs-kafka-connector
@@ -19,6 +19,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
@@ -44,10 +46,6 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -20,7 +20,11 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
+
+
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -23,10 +23,7 @@ MUT_PREFIX ?= $(PROJECT)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
+include ~/shared.mk
 
 next-gen-html:
 	# snooty parse and then build-front-end
@@ -51,8 +48,8 @@ next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
 	@echo "mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};"
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-	$(MAKE) next-gen-deploy-search-index
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-mongocli.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs-mongodb-shell
+++ b/makefiles/Makefile.docs-mongodb-shell
@@ -23,11 +23,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
-	
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
@@ -52,9 +49,4 @@ get-build-dependencies:
 
 next-gen-deploy:	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
-
-	
-next-gen-deploy-search-index: ## Update the search index for this branch
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";

--- a/makefiles/Makefile.docs-mongodb-vscode
+++ b/makefiles/Makefile.docs-mongodb-vscode
@@ -22,6 +22,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
@@ -46,7 +48,7 @@ get-build-dependencies:
 
 next-gen-deploy:	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
 next-gen-deploy-search-index: ## Update the search index for this branch

--- a/makefiles/Makefile.docs-node
+++ b/makefiles/Makefile.docs-node
@@ -22,6 +22,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml
 

--- a/makefiles/Makefile.docs-realm
+++ b/makefiles/Makefile.docs-realm
@@ -15,9 +15,10 @@ PROJECT=realm
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
-
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
 
 next-gen-html:
 	# snooty parse and then build-front-end
@@ -44,11 +45,5 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
-
-
-## Update the search index for this branch
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-spark-connector
+++ b/makefiles/Makefile.docs-spark-connector
@@ -20,6 +20,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
@@ -45,7 +47,7 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
 next-gen-deploy-search-index: ## Update the search index for this branch

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -14,6 +14,8 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 # "PROJECT" currently exists to support having multiple projects
 # within one bucket. For the manual it is empty.
 

--- a/makefiles/Makefile.docs-tutorials
+++ b/makefiles/Makefile.docs-tutorials
@@ -16,6 +16,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 DRIVERS_PATH=source/driver-examples
 
 .PHONY: examples help html publish stage deploy deploy-search-index
@@ -57,7 +59,7 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index
 
 

--- a/makefiles/Makefile.govcloud-docs
+++ b/makefiles/Makefile.govcloud-docs
@@ -21,6 +21,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 .PHONY: help stage fake-deploy deploy deploy-search-index publish remote-includes api-docs
 
 

--- a/makefiles/Makefile.mms-docs
+++ b/makefiles/Makefile.mms-docs
@@ -26,6 +26,8 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+include ~/shared.mk
+
 # Parse our published-branches configuration file to get the name of
 # the current "stable" branch. This is weird and dumb, yes.
 STABLE_BRANCH=`grep 'manual' build/docs-tools/data/mms-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
@@ -91,7 +93,7 @@ get-build-dependencies:
 next-gen-deploy:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}/index.html";
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 
 
 ##########################################################

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -1,0 +1,14 @@
+INTEGRATION_SEARCH_BUCKET=docs-search-indexes-integration
+
+ifeq ($(SNOOTY_INTEGRATION),true)
+	BUCKET_FLAG=-b ${INTEGRATION_SEARCH_BUCKET}
+endif
+
+get-project-name:
+	@echo ${PROJECT};
+
+## Update the search index for this branch
+next-gen-deploy-search-index:
+	@echo "Building search index"
+	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
+


### PR DESCRIPTION
This PR contains the necessary makefile side changes to fix bugs associated with generating the search index manifest filename on the autobuilder. 

I also used this as an opportunity to start the work of the shared makefile, as this solution required adding an identical target to all of our makefiles (get-project-name). 


This sheet contains all the functional tests I did to verify the new work:
https://docs.google.com/spreadsheets/d/1R1Jqx1OOZX37JzTppouNMxwckJCpXtOAQXGScM09bwI/edit?usp=sharing

PR for the node side changes to come ASAP