### PR TITLE
Correct mut-index invocation in vscode makefile

### DIFF
--- a/makefiles/Makefile.docs-mongodb-vscode
+++ b/makefiles/Makefile.docs-mongodb-vscode
@@ -51,4 +51,4 @@ next-gen-deploy:
 
 next-gen-deploy-search-index: ## Update the search index for this branch
 	@echo "Building search index"
-	mut-index upload public -o ${PROJECT}-${GIT_BRANCH}.json -u ${PRODUCTION_URL} -s
+	mut-index upload public -o ${PROJECT}-${GIT_BRANCH}.json -u "${PRODUCTION_URL}/${MUT_PREFIX}" -s


### PR DESCRIPTION
Currently the wrong URL is passed to `mut-index`, so search results 404.