### PR TITLE
DOP-1946: Write sitemap index to root

### DIFF
--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -71,6 +71,7 @@ build-legacy-pages:
 	mkdir -p $@/tools
 	
 	@# Copy CSS and JS files to output directories
+	cp static/sitemap-index.xml $@/sitemap-index.xml
 	cp static/favicon.png $@/favicon.ico
 	for prefix in $@/ $@/tools $@/cloud; do \
 		mkdir -p $$prefix/js || exit 1; \


### PR DESCRIPTION
Duplicate makefile update as introduced in https://github.com/mongodb/docs-landing/pull/64.