### PR TITLE
DOP-2025: Add Go docs build pipeline

### DIFF
--- a/makefiles/Makefile.docs-golang
+++ b/makefiles/Makefile.docs-golang
@@ -12,8 +12,6 @@ else
   PRODUCTION_BUCKET=docs-go-integration
 endif
 
-COMMIT_HASH=$(shell git rev-parse --short HEAD)
-
 PREFIX=/drivers/go
 PROJECT=golang
 MUT_PREFIX ?= $(PROJECT)
@@ -29,7 +27,7 @@ get-build-dependencies:
 
 next-gen-html:
 	# snooty parse and then build-front-end
-	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
+	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true"; \
 	if [ $$? -eq 1 ]; then \
 		exit 1; \
 	else \
@@ -39,13 +37,12 @@ next-gen-html:
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty; 
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
-	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
-	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${MUT_PREFIX}" --stage ${ARGS};
-	echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
+	mut-publish public ${STAGING_BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS};
+	echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
 
 next-gen-deploy:	
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi

--- a/makefiles/Makefile.docs-golang
+++ b/makefiles/Makefile.docs-golang
@@ -1,0 +1,58 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+USER=$(shell whoami)
+
+STAGING_URL="https://docs-mongodborg-staging.corp.mongodb.com"
+STAGING_BUCKET=docs-mongodb-org-staging
+
+ifeq ($(SNOOTY_INTEGRATION),false)
+  PRODUCTION_URL="https://docs.mongodb.com"
+  PRODUCTION_BUCKET=docs-mongodb-org-prod
+else
+  PRODUCTION_URL="docs-mongodbcom-integration.corp.mongodb.com"
+  PRODUCTION_BUCKET=docs-go-integration
+endif
+
+COMMIT_HASH=$(shell git rev-parse --short HEAD)
+
+PREFIX=/drivers/go
+PROJECT=golang
+MUT_PREFIX ?= $(PROJECT)
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-golang.yaml > ${REPO_DIR}/published-branches.yaml
+
+next-gen-html:
+	# snooty parse and then build-front-end
+	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}"; \
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi
+	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
+	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty; 
+	cd snooty; \
+	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
+	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
+	npm run build; \
+	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
+
+next-gen-stage: ## Host online for review
+	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${MUT_PREFIX}" --stage ${ARGS};
+	echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
+
+next-gen-deploy:	
+	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
+	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	$(MAKE) next-gen-deploy-search-index
+
+next-gen-deploy-search-index: ## Update the search index for this branch
+	@echo "Building search index"
+	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-golang
+++ b/makefiles/Makefile.docs-golang
@@ -45,7 +45,7 @@ next-gen-stage: ## Host online for review
 	echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
 
 next-gen-deploy:	
-	if [ ${GIT_BRANCH} = main ]; then mut-redirects config/redirects -o public/.htaccess; fi
+	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index

--- a/makefiles/Makefile.docs-golang
+++ b/makefiles/Makefile.docs-golang
@@ -45,7 +45,7 @@ next-gen-stage: ## Host online for review
 	echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
 
 next-gen-deploy:	
-	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
+	if [ ${GIT_BRANCH} = main ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	$(MAKE) next-gen-deploy-search-index

--- a/publishedbranches/docs-golang.yaml
+++ b/publishedbranches/docs-golang.yaml
@@ -1,0 +1,15 @@
+prefix: '/drivers/go'
+ version:
+   published:
+     - 'main'
+   active:
+     - 'main'
+   stable: 'main'
+ git:
+   branches:
+     manual: 'main'
+     published:
+       - 'main'
+       # the branches/published list **must** be ordered from most to
+       # least recent release.
+ ...


### PR DESCRIPTION
[[DOP-2025](https://jira.mongodb.org/browse/DOP-2025)]
- Do not include commit hashes in staging jobs
- The [mongodb/docs-golang](https://github.com/mongodb/docs-golang) repo will be using `main` as its primary branch name instead of `master`; I tried to reflect that here but not sure if there is anywhere else where that would have an impact
- It looks like every repo has its own integration bucket, so perhaps we need to make one?