### PR TITLE
Updates the URL whence we download pip2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y install libpython2.7-dev python2.7 git rsync
 RUN apt-get -y install curl
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 RUN python2.7 get-pip.py
 RUN pip install requests virtualenv virtualenvwrapper py-dateutil
 RUN python2.7 -m pip install python-dateutil 


### PR DESCRIPTION
Per this lovely debugging message:

```
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
```