### PR TITLE
Unindex autopilot page in cloud-docs

### DIFF
--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -58,6 +58,7 @@ next-gen-deploy:
 	@yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
+	mut-index upload public -o atlas-${GIT_BRANCH}.json -u ${PRODUCTION_URL} -g -s --exclude public/performance-advisor/autopilot.html
 
 
 get-build-dependencies: 


### PR DESCRIPTION
This update attempts to unindex the [Autopilot Mode page](https://docs.atlas.mongodb.com/performance-advisor/autopilot/) in the Atlas docs (cloud-docs repo).

Of note, I'm using step 3 outlined in [this procedure](https://wiki.corp.mongodb.com/pages/viewpage.action?spaceKey=DE&title=Hiding+content+from+Google+and+Marian+search). After speaking with @sophstad, it sounds like we should not refer to the `build` folder on next-gen, so I've removed `build` from the line.

Let me know if this looks ok.

Thank you!