### PR TITLE
renames stable to current

### DIFF
--- a/publishedbranches/docs-node.yaml
+++ b/publishedbranches/docs-node.yaml
@@ -2,10 +2,10 @@ prefix: 'drivers/node'
 version:
   published:
     - '4.0 (upcoming)'
-    - '3.6 (stable)'
+    - '3.6 (current)'
   active:
     - '4.0 (upcoming)'
-    - '3.6 (stable)'
+    - '3.6 (current)'
   stable: 'v3.6'
   upcoming: 'v4.0'
 git:


### PR DESCRIPTION
Renaming stable to current to follow other driver patterns. We will update aliases once this is merged.