### PR TITLE
DOP-2043 allow multiple autobuilder staging instances

### DIFF
--- a/worker/tests/unit/mongo.test.js
+++ b/worker/tests/unit/mongo.test.js
@@ -269,7 +269,7 @@ describe('Mongo Tests', () => {
    ******************************************************************* */
   it('logInMongoWorks', async () => {
     const jobsColl = db.collection('jobs');
-    mongo.getQueueCollection = jest.fn().mockReturnValue(jobsColl);
+    mongo.getCollection = jest.fn().mockReturnValue(jobsColl);
     job2.numFailures = 0;
 
     await mongo.logMessageInMongo(job2, 'message 1');
@@ -291,7 +291,7 @@ describe('Mongo Tests', () => {
     expect(currJob.logs.try1).toHaveLength(1);
     expect(currJob.logs.try1[0]).toEqual('message 3');
 
-    mongo.getQueueCollection = jest.fn().mockReturnValue();
+    mongo.getCollection = jest.fn().mockReturnValue();
     await mongo.logMessageInMongo(job2, 'message 1');
   }, 5000);
 

--- a/worker/utils/environment.js
+++ b/worker/utils/environment.js
@@ -5,6 +5,7 @@ const atlasUsername = process.env.MONGO_ATLAS_USERNAME;
 const atlasPassword = process.env.MONGO_ATLAS_PASSWORD;
 const xlarge = process.env.XLARGE;
 const jobDb = process.env.DB_NAME;
+const jobCol = process.env.COL_NAME;
 
 class EnvironmentClass {
   static getDB() {
@@ -12,6 +13,15 @@ class EnvironmentClass {
       return 'pool_test';
     }
     return jobDb;
+  }
+
+  /* collection name is dynamic to allow mult staging autobuilder instances running
+     at same time without picking up each other's jobs */
+  static getCollection() {
+    if (jobCol === undefined) {
+      return 'queue';
+    }
+    return jobCol;
   }
 
   static getXlarge() {

--- a/worker/utils/mongo.js
+++ b/worker/utils/mongo.js
@@ -9,8 +9,8 @@ const runXlarge = EnvironmentClass.getXlarge();
 const url = `mongodb+srv://${username}:${password}@cluster0-ylwlz.mongodb.net/admin?retryWrites=true`;
 
 // Collection information
-const DB_NAME = EnvironmentClass.getDB(); // Database name of the queue in MongoDB Atlas
-const COLL_NAME = 'queue'; // Collection name of the queue in MongoDB Atlas
+const DB_NAME = EnvironmentClass.getDB(); // Database name for autobuilder in MongoDB Atlas
+const COLL_NAME = EnvironmentClass.getCollection(); // Collection name in MongoDB Atlas
 const META_NAME = 'meta';
 const MONITOR_NAME = 'monitor';
 const ENTITLEMENTS_NAME = 'entitlements';
@@ -33,7 +33,7 @@ module.exports = {
     return null;
   },
   // Gets the Queue Collection
-  getQueueCollection() {
+  getCollection() {
     if (client) {
       return client.db(DB_NAME).collection(COLL_NAME);
     }
@@ -91,9 +91,14 @@ module.exports = {
     };
 
     const update = { $set: { startTime: new Date(), status: 'inProgress' } };
-    const options = { sort: { priority: -1, createdTime: 1 } };
-    await queueCollection.findOne({ status: 'inQueue' });
-    return queueCollection.findOneAndUpdate(query, update, options);
+    const options = { sort: { priority: -1, createdTime: 1 }, returnNewDocument: true };
+
+    try {
+      return queueCollection.findOneAndUpdate(query, update, options);
+    } catch (error) {
+      console.log(error)
+      throw error
+    }
   },
 
   // Sends Job To completed Status and Sets End Time
@@ -133,7 +138,7 @@ module.exports = {
 
   // Adds Log Message To Job In The Queue
   async logMessageInMongo(currentJob, message) {
-    const queueCollection = module.exports.getQueueCollection();
+    const queueCollection = module.exports.getCollection();
     if (queueCollection) {
       const query = { _id: currentJob._id };
       const update = {
@@ -151,7 +156,7 @@ module.exports = {
   },
   // Adds Log Message To Job In The Queue
   async populateCommunicationMessageInMongo(currentJob, message) {
-    const queueCollection = module.exports.getQueueCollection();
+    const queueCollection = module.exports.getCollection();
     if (queueCollection) {
       const query = { _id: currentJob._id };
       const update = {

--- a/worker/utils/mongo.js
+++ b/worker/utils/mongo.js
@@ -96,7 +96,7 @@ module.exports = {
     try {
       return queueCollection.findOneAndUpdate(query, update, options);
     } catch (error) {
-      console.log(error)
+      console.trace(error)
       throw error
     }
   },

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -116,7 +116,7 @@ module.exports = {
     // This is the collection that houses the work tickets
     mongoClient = await mongo.initMongoClient();
     if (mongoClient) {
-      queueCollection = mongo.getQueueCollection();
+      queueCollection = mongo.getCollection();
     }
     monitorInstance.reportStatus('start server');
 


### PR DESCRIPTION
In the current iteration of the docs-worker-pool, every instance of the autobuilder is spun up to listen to updates to the same, single collection. This is great for production - we have four autobuilder instances listening to the same collection, thus building sites faster and more robustly. However, it represents a huge bottleneck for staging. 

If multiple staging instances of the autobuilder are up, each instance will pick up a job whenever it becomes available despite the fact that a job may have been intended to run on a different staging instance that has different tests implemented.  This is why I've always had to ask when the team wanted to test on integration - because I needed my tests jobs to be run through my staging instance (especially if I was testing publish/deploys!). 

This PR reflects the node-js side changes required to enable multiple autobuilder staging instances running at the same time, without picking up each other's jobs. 

The other work required will be: 
1. Create a collection in the testing database that reflects your name. 
2. Create a webhook in the staging realm app for the autobuilder that adds jobs to your personal collection. 
3. Add a monitor to your personal collection so that slack is triggered to send you a message on any update to a doc in your personal collection (I have yet to do this step for myself - we should probably create a ticket for this, as the queue dashboard right now only works for the single staging collection and i'm not sure how it would handle multiple / what changes would be required)