### PR TITLE
DEVHUB-636: Consume STRAPI_PUBLICATION_STATE

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -5,6 +5,7 @@ STAGING_URL="http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com"
 STAGING_BUCKET=docs-devhub-staging
 
 STRAPI_URL=http://54.219.137.111:1337
+STRAPI_PUBLICATION_STATE = $(shell printenv STRAPI_PUBLICATION_STATE)
 
 PRODUCTION_BUCKET=docs-devhub-prod
 PRODUCTION_URL=https://developer.mongodb.com
@@ -45,6 +46,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
+	echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
   

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,9 +45,6 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
-		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
-	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
   

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -46,7 +46,9 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
+	if [ ! -z "$STRAPI_PUBLICATION_STATE" ]; then \
+		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
+	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
   

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z "$STRAPI_PUBLICATION_STATE" ]; then \
+	if [ ! -z $STRAPI_PUBLICATION_STATE ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,6 +45,9 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
+	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
+		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
+	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
   

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z $STRAPI_PUBLICATION_STATE ]; then \
+	if [ ! -z ${STRAPI_PUBLICATION_STATE} ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -5,7 +5,6 @@ STAGING_URL="http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com"
 STAGING_BUCKET=docs-devhub-staging
 
 STRAPI_URL=http://54.219.137.111:1337
-STRAPI_PUBLICATION_STATE = $(shell printenv STRAPI_PUBLICATION_STATE)
 
 PRODUCTION_BUCKET=docs-devhub-prod
 PRODUCTION_URL=https://developer.mongodb.com

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z ${STRAPI_PUBLICATION_STATE} ]; then \
+	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z ${STRAPI_PUBLICATION_STATE} ]; then \
+	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z "$STRAPI_PUBLICATION_STATE" ]; then \
+	if [ ! -z $STRAPI_PUBLICATION_STATE ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,6 +45,9 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
+	if [ ! -z "$STRAPI_PUBLICATION_STATE" ]; then \
+		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
+	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,6 +45,9 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
+	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
+		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
+	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ ! -z $STRAPI_PUBLICATION_STATE ]; then \
+	if [ ! -z ${STRAPI_PUBLICATION_STATE} ]; then \
 		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
 	fi
 	npm run build; \

--- a/makefiles/Makefile.devhub-content-integration
+++ b/makefiles/Makefile.devhub-content-integration
@@ -45,9 +45,6 @@ next-gen-html: update-snooty
 	echo "GATSBY_PARSER_BRANCH=${GIT_BRANCH}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	if [ -n ${STRAPI_PUBLICATION_STATE} ]; then \
-		echo "STRAPI_PUBLICATION_STATE=${STRAPI_PUBLICATION_STATE}" >> .env.production; \
-	fi
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 


### PR DESCRIPTION
This PR attempts (keyword!) to use the `STRAPI_PUBLICATION_STATE` variable defined in [this branch](https://github.com/mongodb/docs-worker-pool/compare/master...madelinezec:DOP-2144?expand=1) and pipe it to the `env.production` file. I also opted to wrap in a conditional to only add the field should it exist.

This _should_ do the trick?