### PR TITLE
fix manual published branches for 5.0 version bump

### DIFF
--- a/publishedbranches/docs.yaml
+++ b/publishedbranches/docs.yaml
@@ -22,10 +22,10 @@ version:
   upcoming: '5.0'
 git:
   branches:
-    manual: 'master'
+    manual: 'v4.4'
     published:
-      - 'v5.0'
       - 'master'
+      - 'v4.4'
       - 'v4.2'
       - 'v4.0'
       - 'v3.6'


### PR DESCRIPTION
We've bumped the versions in our GitHub repo so now v5.0 content lives on branch `master` and v4.4 content lives on branch `v4.4`.