### PR TITLE
Add missing mut-redirects to Makefile.docs

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -112,7 +112,8 @@ deploy: build/public ## Deploy to the production bucket
 	$(MAKE) next-gen-deploy-search-index
 
 
-next-gen-deploy:	
+next-gen-deploy:
+	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=https://docs.mongodb.com --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
 	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi


### PR DESCRIPTION
Seems like we weren't calling `mut-redirects` when we should be.