### PR TITLE
(DOCSP-17512): Remove 'upcoming' from manual version flipper for 5.0

### DIFF
--- a/publishedbranches/docs.yaml
+++ b/publishedbranches/docs.yaml
@@ -1,7 +1,7 @@
 prefix: ''
 version:
   published:
-    - '5.0 (upcoming)'
+    - '5.0'
     - '4.4'
     - '4.2'
     - '4.0'
@@ -13,15 +13,14 @@ version:
     - '2.4'
     - '2.2'
   active:
-    - '5.0 (upcoming)'
+    - '5.0'
     - '4.4'
     - '4.2'
     - '4.0'
-  stable: '4.4'
-  upcoming: '5.0'
+  stable: '5.0'
 git:
   branches:
-    manual: 'v4.4'
+    manual: 'master'
     published:
       - 'master'
       - 'v4.4'


### PR DESCRIPTION
NOTE: I'm not entirely sure I did this correctly because I'm a little foggy on the meanings of `stable`, `upcoming`, and `git.branches.manual`. I feel like in next-gen these don't do anything but might be misremembering.