### PR TITLE
DOP-2311: add phplib published branches so we can stage with snooty

### DIFF
--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -12,14 +12,17 @@ else
 endif
 
 PROJECT=php-library
+PREFIX=php-library
+MUT_PREFIX ?= $(PROJECT)
+REPO_DIR=$(shell pwd)
 
-# Parse our published-branches configuration file to get the name of
-# the current "stable" branch. This is weird and dumb, yes.
-STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
-.PHONY: help publish stage deploy deploy-search-index
+include ~/shared.mk
 
-
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-php-library.yaml > ${REPO_DIR}/published-branches.yaml
 
 html:
 	giza make html

--- a/publishedbranches/docs-php-library.yaml
+++ b/publishedbranches/docs-php-library.yaml
@@ -1,0 +1,40 @@
+prefix: 'php-library'
+version:
+  published:
+    - 'master'
+    - '1.8'
+    - '1.7'
+    - '1.6'
+    - '1.5'
+    - '1.4'
+    - '1.3'
+    - '1.2'
+    - '1.1'
+  active:
+    - 'master'
+    - '1.8'
+    - '1.7'
+    - '1.6'
+    - '1.5'
+    - '1.4'
+    - '1.3'
+    - '1.2'
+    - '1.1'
+  stable: '1.8'
+  upcoming: 'master'
+git:
+  branches:
+    manual: 'v1.8'
+    published:
+      - 'master'
+      - 'v1.8'
+      - 'v1.7'
+      - 'v1.6'
+      - 'v1.5'
+      - 'v1.4'
+      - 'v1.3'
+      - 'v1.2'
+      - 'v1.1'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...


### PR DESCRIPTION
Requisite updates to make phplib buildable on snooty so we can assess how much work it's going to be to migrate.