### PR TITLE
DOP-2343: fix mut prefix for manual to align with legacy

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -13,7 +13,7 @@ endif
 
 PREFIX=manual
 PROJECT=docs
-MUT_PREFIX ?= $(PROJECT)
+MUT_PREFIX ?= $(PREFIX)
 REPO_DIR=$(shell pwd)
 
 PATCH_FILE="myPatch.patch"


### PR DESCRIPTION
Legacy writes the manual's search indexes to manual-, so this makes us do the same.