### PR TITLE
DOP-2343: (TEMP HACK) fix manifest prefix for manual to align with legacy

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -23,10 +23,10 @@ SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
 
-include ~/shared.mk
+CUSTOM_SEARCH_INDEX=true
+CUSTOM_NEXT_GEN_DEPLOY=true
 
-# "PROJECT" currently exists to support having multiple projects
-# within one bucket. For the manual it is empty.
+include ~/shared.mk
 
 DRIVERS_PATH=source/driver-examples
 
@@ -85,6 +85,22 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${STAGING_BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
+
+next-gen-deploy:
+	if [ -f config/redirects -a "${GIT_BRANCH}" = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
+	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=${PRODUCTION_URL} --json --all-subdirectories ${ARGS};
+	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
+	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
+endif
+
+next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
+	@echo "Building search index"
+	MANUAL_INDEX=$(subst docs,manual,${MANIFEST_PREFIX})
+	ifeq ($(MANUAL_INDEX), "manual-manual")
+	MANUAL_INDEX="manual-v5.0"
+	endif
+	
+	mut-index upload public -o ${MANUAL_INDEX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -24,7 +24,6 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
 
 CUSTOM_SEARCH_INDEX=true
-CUSTOM_NEXT_GEN_DEPLOY=true
 
 include ~/shared.mk
 
@@ -86,20 +85,13 @@ next-gen-stage: ## Host online for review
 		echo "Hosted at ${STAGING_URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
 
-next-gen-deploy:
-	if [ -f config/redirects -a "${GIT_BRANCH}" = master ]; then mut-redirects config/redirects -o public/.htaccess; fi	
-	yes | mut-publish public ${PRODUCTION_BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=${PRODUCTION_URL} --json --all-subdirectories ${ARGS};
-	@echo "Hosted at ${PRODUCTION_URL}/${MUT_PREFIX}";
-	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
-endif
-
 next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
 	@echo "Building search index"
 	MANUAL_INDEX=$(subst docs,manual,${MANIFEST_PREFIX})
 	ifeq ($(MANUAL_INDEX), "manual-manual")
 	MANUAL_INDEX="manual-v5.0"
 	endif
-	
+
 	mut-index upload public -o ${MANUAL_INDEX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
 
 get-build-dependencies: 

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -63,6 +63,8 @@ next-gen-stage: ## Host online for review
 endif
 
 ## Update the search index for this branch
+## Manual has its own custom search index, because it is special.
+ifndef CUSTOM_SEARCH_INDEX
 next-gen-deploy-search-index:
 	@echo "Building search index"
 	mut-index upload public -o ${MANIFEST_PREFIX}.json -u ${PRODUCTION_URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)


### PR DESCRIPTION
Ugh.

Relevant context: for reasons that are hard to deduce, we upload the Manual's search index manifest as docs-<something> rather than manual-<Something>. Because of the way the front-end works, that means we have "Docs" as a "Product" and "Manual" as a product, which is obviously silly. This will (very hackily) fix that situation while we sort out a more permanent solution as part of the Version Management project.