### PR TITLE
(DOCSP-18215): Update manual published branches for 5.1 upcoming

### DIFF
--- a/publishedbranches/docs.yaml
+++ b/publishedbranches/docs.yaml
@@ -1,6 +1,7 @@
 prefix: ''
 version:
   published:
+    - '5.1 (upcoming)'
     - '5.0'
     - '4.4'
     - '4.2'
@@ -13,16 +14,18 @@ version:
     - '2.4'
     - '2.2'
   active:
+    - '5.1 (upcoming)'
     - '5.0'
     - '4.4'
     - '4.2'
     - '4.0'
-  stable: '5.0'
+  stable: 'v5.0'
 git:
   branches:
-    manual: 'master'
+    manual: 'v5.0'
     published:
       - 'master'
+      - 'v5.0'
       - 'v4.4'
       - 'v4.2'
       - 'v4.0'


### PR DESCRIPTION
The goal of this PR is to create a new published branch of the manual for 5.1 content. The version dropdown should read `v5.1 (upcoming)`, and the corresponding GitHub branch for v5.1 content is `master`.