### PR TITLE
Add 'Version' string to manual 5.1 dropdown entry

### DIFF
--- a/publishedbranches/docs.yaml
+++ b/publishedbranches/docs.yaml
@@ -1,7 +1,7 @@
 prefix: ''
 version:
   published:
-    - '5.1 (upcoming)'
+    - 'Version 5.1 (upcoming)'
     - '5.0'
     - '4.4'
     - '4.2'
@@ -14,7 +14,7 @@ version:
     - '2.4'
     - '2.2'
   active:
-    - '5.1 (upcoming)'
+    - 'Version 5.1 (upcoming)'
     - '5.0'
     - '4.4'
     - '4.2'


### PR DESCRIPTION
Since the 5.1 version dropdown entry is non-numeric, we need to explicitly specify "Version" for "Version" to appear in the dropdown copy.