### PR TITLE
DOP-2415: docs-mongocli: pull git submodule

### DIFF
--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -25,5 +25,6 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-get-build-dependencies: 
+get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-mongocli.yaml > ${REPO_DIR}/published-branches.yaml
+	git submodule update --remote --init


### PR DESCRIPTION
the mongocli docs are introducing a git submodule that we need to pull during build