### PR TITLE
DEVHUB-505: Use Universal PATH_PREFIX for staging

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	fi
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR}; 
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty-devhub;
-	cd snooty-devhub; \
+	cd ${REPO_DIR}/snooty-devhub; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -43,13 +43,13 @@ next-gen-html: update-snooty
 	else \
 		exit 0; \
 	fi
+	# If prod --> set PATH_PREFIX build arg to /developer
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR}; 
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty-devhub;
-	cd /home/docsworker-xlarge/repos/devhub-content/snooty-devhub; \
+	cd /home/docsworker-xlarge/repos/devhub-content/snooty-devhub;
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \
-	# If prod --> set PATH_PREFIX build arg to /developer
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
 

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -56,9 +56,9 @@ next-gen-html: update-snooty
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
-	mut-publish public ${STAGING_BUCKET} --prefix="${COMMIT_HASH}/${MUT_PREFIX}" --stage ${ARGS};
+	mut-publish public ${STAGING_BUCKET} --prefix=/developer --stage ${ARGS};
 	echo "${COMMIT_HASH}/${MUT_PREFIX}"
-	echo "Hosted at ${STAGING_URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
+	echo "Hosted at ${STAGING_URL}/developer";
 
 next-gen-deploy:
 	yes | mut-publish ./public ${PRODUCTION_BUCKET} --prefix=/developer --deploy --deployed-url-prefix=https://mongodb.com/developer --json --all-subdirectories ${ARGS};

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -1,8 +1,8 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
 
-STAGING_URL="http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com"
-STAGING_BUCKET=docs-devhub-staging
+STAGING_URL="http://developer-hub-staging.s3-website-us-east-1.amazonaws.com"
+STAGING_BUCKET=developer-hub-staging
 
 STRAPI_URL=http://54.219.137.111:1337
 
@@ -47,6 +47,7 @@ next-gen-html: update-snooty
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR}; 
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty-devhub;
 	cd /home/docsworker-xlarge/repos/devhub-content/snooty-devhub;
+	$(shell ls)
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \

--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -45,7 +45,7 @@ next-gen-html: update-snooty
 	fi
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty-devhub ${REPO_DIR}; 
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty-devhub;
-	cd ${REPO_DIR}/snooty-devhub; \
+	cd /home/docsworker-xlarge/repos/devhub-content/snooty-devhub; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
 	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	echo "STRAPI_URL=${STRAPI_URL}" >> .env.production; \


### PR DESCRIPTION
As a result of using `PATH_PREFIX` in next-gen-html for all jobs, we should update the s3 bucket push to be /developer and update in place