### PR TITLE
Update golang prefixes

### DIFF
--- a/makefiles/Makefile.docs-golang
+++ b/makefiles/Makefile.docs-golang
@@ -2,7 +2,7 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 USER=$(shell whoami)
 
-PREFIX=drivers/go
+PREFIX=drivers/go/master
 PROJECT=golang
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)

--- a/publishedbranches/docs-golang.yaml
+++ b/publishedbranches/docs-golang.yaml
@@ -1,4 +1,4 @@
-prefix: 'drivers/go'
+prefix: 'drivers/go/master'
 version:
   published:
     - 'master'


### PR DESCRIPTION
This is sort of a hacky way to get `docs-golang` to publish to both `drivers/go/master` while its alias publishes to `drivers/go/current` without actually having two active branches/versions.

We definitely need to make the appropriate adjustments when prepping the repo for another branch.