### PR TITLE
Remove Charts 19.12 from version and git fields

### DIFF
--- a/publishedbranches/docs-charts.yaml
+++ b/publishedbranches/docs-charts.yaml
@@ -2,17 +2,14 @@ prefix: 'charts'
 version:
   published:
     - 'Cloud'
-    - '19.12 (On-Prem)'
   active:
     - 'Cloud'
-    - '19.12 (On-Prem)'
   stable: 'master'
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
-      - '19.12'
 
       # the branches/published list **must** be ordered from most to
       # least recent release.


### PR DESCRIPTION
[DOCSP ticket requesting Charts 19.12 be removed from dropdown](https://jira.mongodb.org/browse/DOCSP-18822)