### PR TITLE
Upload DevHub staging to exactly /developer

### DIFF
--- a/makefiles/Makefile.devhub-content
+++ b/makefiles/Makefile.devhub-content
@@ -57,7 +57,7 @@ next-gen-html: update-snooty
 	cp -r "${REPO_DIR}/snooty-devhub/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review
-	mut-publish public ${STAGING_BUCKET} --prefix=/developer --stage ${ARGS};
+	mut-publish public ${STAGING_BUCKET} --prefix=/developer --deploy ${ARGS};
 	echo "${COMMIT_HASH}/${MUT_PREFIX}"
 	echo "Hosted at ${STAGING_URL}/developer";
 


### PR DESCRIPTION
I believe this is a bug where I don't quite understand `mut-publish` correctly. The [--stage](https://github.com/mongodb/mut/blob/master/mut/stage.py) option seems to ignore `--prefix` whereas the --deploy one does not?

A bit confused but the desired behavior for a staging job is to push content to s3 right at the prefix. I can also just copy the prod deploy line and change the bucket but this might be easier

cc @casthewiz @GuruPKK 