### PR TITLE
DOP-2571: execSync with increased buffer

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -20,6 +20,7 @@
     "MIN_TIMEOUT_MS": 1,
     "LOG_PADDING": 15,
     "PORT": 3000,
+    "MAX_STDOUT_BUFFER_SIZE": 16000000,
     "GATSBY_PARSER_USER": "docsworker-xlarge",
     "shouldPurgeAll": false,
     "fastlyOpsManagerToken": "FASTLY_OPS_MANAGER_TOKEN",

--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -1,5 +1,3 @@
-
-import { promisify } from "util";
 import cp from 'child_process';
 
 export class CommandExecutorResponse {
@@ -25,16 +23,11 @@ export interface IGithubCommandExecutor {
 
 export class ShellCommandExecutor implements ICommandExecutor {
     async execute(commands: string[]): Promise<CommandExecutorResponse> {
-        let exec = promisify(cp.exec);
         let resp = new CommandExecutorResponse();
         const MAX_BUFFER_SIZE = 16000000;
         try {
-            const {
-                stdout,
-                stderr
-            } = await exec(commands.join(' && '), {maxBuffer : MAX_BUFFER_SIZE});
-            resp.output = stdout.trim();
-            resp.error = stderr;
+            const stdout = cp.execSync(commands.join(' && '), {maxBuffer : MAX_BUFFER_SIZE});
+            resp.output = stdout?.toString().trim();
             resp.status = 'success';
             return resp;
         } catch (error) {

--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -27,11 +27,12 @@ export class ShellCommandExecutor implements ICommandExecutor {
     async execute(commands: string[]): Promise<CommandExecutorResponse> {
         let exec = promisify(cp.exec);
         let resp = new CommandExecutorResponse();
+        const MAX_BUFFER_SIZE = 16000000;
         try {
             const {
                 stdout,
                 stderr
-            } = await exec(commands.join(' && '));
+            } = await exec(commands.join(' && '), {maxBuffer : MAX_BUFFER_SIZE});
             resp.output = stdout.trim();
             resp.error = stderr;
             resp.status = 'success';

--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -1,4 +1,5 @@
 import cp from 'child_process';
+import c from 'config';
 
 export class CommandExecutorResponse {
     status: string;
@@ -24,9 +25,9 @@ export interface IGithubCommandExecutor {
 export class ShellCommandExecutor implements ICommandExecutor {
     async execute(commands: string[]): Promise<CommandExecutorResponse> {
         let resp = new CommandExecutorResponse();
-        const MAX_BUFFER_SIZE = 16000000;
+        
         try {
-            const stdout = cp.execSync(commands.join(' && '), {maxBuffer : MAX_BUFFER_SIZE});
+            const stdout = cp.execSync(commands.join(' && '), {maxBuffer : c.get('MAX_STDOUT_BUFFER_SIZE')});
             resp.output = stdout?.toString().trim();
             resp.status = 'success';
             return resp;

--- a/tests/jobManager.integration.test.ts
+++ b/tests/jobManager.integration.test.ts
@@ -37,6 +37,7 @@ describe('Jobmanager integration Tests', () => {
     let repoConnector: GitHubConnector;
     let jobHandletFactory: JobHandlerFactory;
     let jobManager: JobManager;
+    jest.setTimeout(18000);
     beforeEach(() => {
         consoleLogger = new ConsoleLogger();
         fileSystemServices = new FileSystemServices();

--- a/tests/unit/services/gitHubCommandExecutor.test.ts
+++ b/tests/unit/services/gitHubCommandExecutor.test.ts
@@ -21,58 +21,50 @@ describe('GithubCommandExecutor Tests', () => {
     describe('GithubCommandExecutor applyPatch Tests', () => {
         test('GithubCommandExecutor applyPatch  succeeds', async() => {
             const testData = TestDataProvider.getPatchCommands("test_repo", "test_patch");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'patch applied properly  ' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('patch applied properly  '));
             let resp = await commandExecutor.applyPatch('test_repo', 'test_patch');
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe('patch applied properly');
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
     })
 
     describe('GithubCommandExecutor checkoutBranchForSpecificHead Tests', () => {
         test('GithubCommandExecutor checkoutBranchForSpecificHead  succeeds', async() => {
             const testData = TestDataProvider.getcheckoutBranchForSpecificHeadCommands("test_repo", "test_patch", "test_head");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'valid commits' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('valid commits'));
             let resp = await commandExecutor.checkoutBranchForSpecificHead("test_repo", "test_patch", "test_head");
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe('valid commits');
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
     })
 
     describe('GithubCommandExecutor pullRepo Tests', () => {
         test('GithubCommandExecutor pullRepo with valid head  succeeds', async() => {
             const testData = TestDataProvider.getPullRepoCommands("test_repo", "test_patch", "test_head");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'Repo pulled properly' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('Repo pulled properly'));
             let resp = await commandExecutor.pullRepo("test_repo", "test_patch", "test_head");
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe('Repo pulled properly' );
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
 
         test('GithubCommandExecutor pullRepo with no head  succeeds', async() => {
             const testData = TestDataProvider.getPullRepoCommands("test_repo", "test_patch");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'Repo pulled properly' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('Repo pulled properly'));
             let resp = await commandExecutor.pullRepo("test_repo", "test_patch");
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe("Repo pulled properly");
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
     })
 })

--- a/tests/unit/services/jobSpecificCommandExecutor.test.ts
+++ b/tests/unit/services/jobSpecificCommandExecutor.test.ts
@@ -21,20 +21,18 @@ describe('JobSpecificCommandExecutor Tests', () => {
     describe('JobSpecificCommandExecutor getSnootyProjectName Tests', () => {
         test('JobSpecificCommandExecutor getSnootyProjectName  succeeds', async() => {
             const testData = TestDataProvider.getCommandsForSnootyProjectName("test_repo");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'test_repo_project_snooty_name' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('test_repo_project_snooty_name'));
             let resp = await commandExecutor.getSnootyProjectName('test_repo');
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe('test_repo_project_snooty_name');
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
 
         test('JobSpecificCommandExecutor getSnootyProjectName  fails return proper response', async() => {
             const testData = TestDataProvider.getCommandsForSnootyProjectName("test_repo");
-            cp.exec.mockImplementation((command, callback) => {
+            cp.execSync.mockImplementation((command, options, callback) => {
                 throw Error("Test error");
                 // callback(null, {stdErr: "invalid command", stdout: 'test_repo_project_snooty_name' });
             });
@@ -48,15 +46,13 @@ describe('JobSpecificCommandExecutor Tests', () => {
     describe('JobSpecificCommandExecutor getServerUser Tests', () => {
         test('JobSpecificCommandExecutor getServerUser  succeeds', async() => {
             const testData = TestDataProvider.getCommandsForGetServerUser("test_repo");
-            cp.exec.mockImplementation((command, callback) => {
-                callback(null, { stdout: 'test_user_in_test_machine' });
-            });
+            cp.execSync.mockImplementation((command, options, callback) => Buffer.from('test_user_in_test_machine'));
             let resp = await commandExecutor.getServerUser();
             expect(resp.error).toBe(undefined);
             expect(resp.output).toBe('test_user_in_test_machine');
             expect(resp.status).toBe('success');
-            expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-            expect(cp.exec).toBeCalledTimes(1);
+            expect(cp.execSync.mock.calls[0][0]).toEqual(testData.join(' && '));
+            expect(cp.execSync).toBeCalledTimes(1);
         })
     })
 })


### PR DESCRIPTION
Switches our usage of `promisify` and `child_process.exec` to `child_process.execSync`, with an increased buffer size of 16MB for verbose log ouptuts

https://nodejs.org/api/child_process.html#child_processexecsynccommand-options


Updates tests to reflect new usage