### PR TITLE
hotfix: Update output for changed error signature

### DIFF
--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -34,6 +34,8 @@ export class ShellCommandExecutor implements ICommandExecutor {
         } catch (error) {
             resp.output = null;
             resp.error = error;
+            resp.error.stdout = error?.stdout?.toString();
+            resp.error.stderr = error?.stderr?.toString();
             resp.status = 'failed';
         }
         return resp;

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -1,4 +1,5 @@
 import { mockReset } from 'jest-mock-extended';
+import { Buffer } from 'buffer'
 import { TestDataProvider } from '../../data/data';
 import { JobHandlerTestHelper } from '../../utils/jobHandlerTestHelper';
 
@@ -172,23 +173,23 @@ describe.each(TestDataProvider.getManifestPrefixCases())('Execute Next Gen Build
     })
 })
 
-test('Execute Build succeeded deploy failed updates status properly', async () => {
-    jobHandlerTestHelper.setStageForDeployFailure("Bad work", "Not Good");
+test('Execute Build succeeded deploy failed updates status properly with out and err', async () => {
+    jobHandlerTestHelper.setStageForDeployFailure(Buffer.from("Bad work"), Buffer.from("Not Good"));
     await jobHandlerTestHelper.jobHandler.execute();
     jobHandlerTestHelper.verifyNextGenSuccess();
     expect(jobHandlerTestHelper.jobRepo.insertNotificationMessages).toBeCalledWith(jobHandlerTestHelper.job._id,  "Bad work");
     expect(jobHandlerTestHelper.jobRepo.updateWithErrorStatus).toBeCalledWith(jobHandlerTestHelper.job._id, "Not Good");
 })
 
-test('Execute Build succeeded deploy failed updates status properly', async () => {
-    jobHandlerTestHelper.setStageForDeployFailure(null, "Not Good");
+test('Execute Build succeeded deploy failed updates status properly on nullish case', async () => {
+    jobHandlerTestHelper.setStageForDeployFailure(null, Buffer.from("Not Good"));
     await jobHandlerTestHelper.jobHandler.execute();
     jobHandlerTestHelper.verifyNextGenSuccess();
-    expect(jobHandlerTestHelper.jobRepo.updateWithErrorStatus).toBeCalledWith(jobHandlerTestHelper.job._id,  "Cannot read property 'replace' of null");
+    expect(jobHandlerTestHelper.jobRepo.updateWithErrorStatus).toBeCalledWith(jobHandlerTestHelper.job._id,  "Not Good");
 })
 
 test('Execute Build succeeded deploy failed with an ERROR updates status properly', async () => {
-    jobHandlerTestHelper.setStageForDeployFailure(null, "ERROR:BAD ONE");
+    jobHandlerTestHelper.setStageForDeployFailure(null, Buffer.from("ERROR:BAD ONE"));
     await jobHandlerTestHelper.jobHandler.execute();
     jobHandlerTestHelper.verifyNextGenSuccess();
     expect(jobHandlerTestHelper.jobRepo.updateWithErrorStatus).toBeCalledWith(jobHandlerTestHelper.job._id, "Failed pushing to Production: ERROR:BAD ONE");

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -1,5 +1,6 @@
 import { IConfig } from "config";
 import { mockDeep } from "jest-mock-extended";
+import { Buffer } from 'buffer';
 import { IJob } from "../../src/entities/job";
 import { IJobValidator } from "../../src/job/jobValidator";
 import { ProductionJobHandler } from "../../src/job/productionJobHandler";
@@ -53,11 +54,11 @@ export class JobHandlerTestHelper {
         return publishOutput[1]; //return urls
     }
 
-    setStageForDeployFailure(deployOutput: string | null, deployError: string) {
+    setStageForDeployFailure(deployOutput: Buffer | null, deployError: Buffer) {
         this.job.payload.publishedBranches = TestDataProvider.getPublishBranchesContent(this.job);
         this.setupForSuccess();
-        this.jobCommandExecutor.execute.mockReturnValueOnce({ status: "success", output: "Great work", error: null });
-        this.jobCommandExecutor.execute.mockReturnValueOnce({ status: "Failed", output: deployOutput, error: deployError })
+        this.jobCommandExecutor.execute.mockReturnValueOnce({ status: "success", output: Buffer.from("Great work"), error: null });
+        this.jobCommandExecutor.execute.mockReturnValueOnce({ status: "Failed", output: deployOutput?.toString(), error: deployError?.toString() })
         this.fileSystemServices.getFilesInDirectory.calledWith(`./${this.job.payload.repoName}/build/public`, '').mockReturnValue(["1.html", "2.html", "3.html"]);
     }
 


### PR DESCRIPTION
Updates our error output to cast buffer to string, and updates relevant tests for the changed return signature.