### PR TITLE
Add Visual Studio Makefile

### DIFF
--- a/makefiles/Makefile.docs-visual-studio-extension
+++ b/makefiles/Makefile.docs-visual-studio-extension
@@ -1,0 +1,18 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+USER=$(shell whoami)
+
+PREFIX=mongodb-visual-studio
+PROJECT=visual-studio-extension
+MUT_PREFIX ?= $(PROJECT)
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-visual-studio-extension.yaml > ${REPO_DIR}/published-branches.yaml


### PR DESCRIPTION
Add a make file [for this repository](https://github.com/mongodb/docs-visual-studio-extension).

Next-Gen configuration scripts [can be found in this branch of this fork](https://github.com/biniona-mongodb/docs-visual-studio-extension/tree/next-gen) of the preceding repository.

### Notes:

I don't understand the structure of this Makefile well, so I largely copied the most recent other Deved-DBX Makefile (the makefile for `docs-golang`). Let me know if anything here looks odd or off the mark.