### PR TITLE
(DOCSP-20213) Update Prefix For docs-visual-studio-extension Repo

### DIFF
--- a/makefiles/Makefile.docs-visual-studio-extension
+++ b/makefiles/Makefile.docs-visual-studio-extension
@@ -2,7 +2,7 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 USER=$(shell whoami)
 
-PREFIX=mongodb-visual-studio
+PREFIX=mongodb-analyzer
 PROJECT=visual-studio-extension
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)

--- a/publishedbranches/docs-visual-studio-extension.yaml
+++ b/publishedbranches/docs-visual-studio-extension.yaml
@@ -1,4 +1,4 @@
-prefix: '/'
+prefix: '/mongodb-analyzer'
 version:
   published:
     - 'main'


### PR DESCRIPTION
Update prefix of docs site. The reason for this change is that the product this site documents was renamed from "Visual Studio Extension" to "MongoDB Analyzer" as the docs set was being written.

This PR is depended on [by this PR](https://github.com/mongodb/docs-visual-studio-extension/pull/10). 