### PR TITLE
remove-loose-babel-option: as described

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
     ],
     "plugins": [
       ["@babel/plugin-proposal-decorators", { "legacy": true }],
-      ["@babel/plugin-proposal-class-properties", { "loose": true }],
+      ["@babel/plugin-proposal-class-properties"],
       "@babel/plugin-transform-runtime"
     ]
 }


### PR DESCRIPTION
During testing, we receive the warning:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

Babel’s loose mode transpiles ES6 code to ES5 code that is less faithful to ES6 semantics. We do not seem to need this feature, so I propose we remove it and stick to stricter ES6 standards