### PR TITLE
Pre commit hook fix: change pathname

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/.husky:pre-commit
+++ b/.husky:pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
- . "$(dirname "$0")/_/husky.sh"
-
- npx --no-install lint-staged


### PR DESCRIPTION
Changes `.husky:pre-commit` to `.husky/pre-commit`. Does not run the formatter in this PR