### PR TITLE
DOP-2549: POC manifest generation infrastructure changes (No SQS)

### DIFF
--- a/api/controllers/v1/github.ts
+++ b/api/controllers/v1/github.ts
@@ -1,5 +1,5 @@
 import c from 'config';
-import crypto from 'crypto';
+import crypto, { Utf8AsciiLatin1Encoding } from 'crypto';
 import mongodb from 'mongodb';
 import { JobRepository } from '../../../src/repositories/jobRepository';
 import { ConsoleLogger } from '../../../src/services/logger';
@@ -7,10 +7,11 @@ import { ConsoleLogger } from '../../../src/services/logger';
 // This function will validate your payload from GitHub
 // See docs at https://developer.github.com/webhooks/securing/#validating-payloads-from-github
 function signRequestBody(key: string, body: string) {
-  return `sha1=${crypto.createHmac('sha1', key).update(body, 'utf-8').digest('hex')}`;
+  const enc = 'utf-8' as Utf8AsciiLatin1Encoding;
+  return `sha1=${crypto.createHmac('sha1', key).update(body, enc).digest('hex')}`;
 }
 
-function prepGithubPushPayload(githubEvent: any) {
+function prepGithubPushPayload(githubEvent: any): any {
   return {
     title: githubEvent.repository.full_name,
     user: githubEvent.pusher.name,
@@ -39,7 +40,7 @@ function prepGithubPushPayload(githubEvent: any) {
   };
 }
 
-export const TriggerBuild = async (event: any = {}, context: any = {}): Promise<any> => {
+export const TriggerBuild = async (event: any = {}): Promise<any> => {
   const client = new mongodb.MongoClient(c.get('dbUrl'));
   await client.connect();
   const db = client.db(c.get('dbName'));

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,17 +32,19 @@ async function init(): Promise<void> {
   await client.connect();
   db = client.db(c.get('dbName'));
   consoleLogger = new ConsoleLogger();
+  githubCommandExecutor = new GithubCommandExecutor();
+  repoEntitlementRepository = new RepoEntitlementsRepository(db, c, consoleLogger);
+
+  // Initialize for new JobManager
+  cdnConnector = new FastlyConnector(consoleLogger);
   fileSystemServices = new FileSystemServices();
   jobCommandExecutor = new JobSpecificCommandExecutor();
-  githubCommandExecutor = new GithubCommandExecutor();
-  jobRepository = new JobRepository(db, c, consoleLogger);
-  hybridJobLogger = new HybridJobLogger(jobRepository);
-  repoEntitlementRepository = new RepoEntitlementsRepository(db, c, consoleLogger);
-  repoBranchesRepo = new RepoBranchesRepository(db, c, consoleLogger);
-  jobValidator = new JobValidator(fileSystemServices, repoEntitlementRepository, repoBranchesRepo);
-  cdnConnector = new FastlyConnector(consoleLogger);
-  repoConnector = new GitHubConnector(githubCommandExecutor, c, fileSystemServices, hybridJobLogger);
   jobHandlerFactory = new JobHandlerFactory();
+  jobRepository = new JobRepository(db, c, consoleLogger);
+  jobValidator = new JobValidator(fileSystemServices, repoEntitlementRepository, repoBranchesRepo);
+  hybridJobLogger = new HybridJobLogger(jobRepository);
+  repoBranchesRepo = new RepoBranchesRepository(db, c, consoleLogger);
+  repoConnector = new GitHubConnector(githubCommandExecutor, c, fileSystemServices, hybridJobLogger);
   jobManager = new JobManager(
     cdnConnector,
     c, // config

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,6 @@ let githubCommandExecutor: GithubCommandExecutor;
 let jobRepository: JobRepository;
 let hybridJobLogger: HybridJobLogger;
 let repoEntitlementRepository: RepoEntitlementsRepository;
-let repoBranchesRepository: RepoBranchesRepository;
 let jobValidator: JobValidator;
 let cdnConnector: FastlyConnector;
 let repoConnector: GitHubConnector;
@@ -45,16 +44,16 @@ async function init(): Promise<void> {
   repoConnector = new GitHubConnector(githubCommandExecutor, c, fileSystemServices, hybridJobLogger);
   jobHandlerFactory = new JobHandlerFactory();
   jobManager = new JobManager(
-    c,
-    jobValidator,
-    jobHandlerFactory,
-    jobCommandExecutor,
-    jobRepository,
     cdnConnector,
-    repoConnector,
+    c, // config
     fileSystemServices,
+    jobCommandExecutor,
+    jobHandlerFactory,
+    jobRepository,
+    jobValidator,
     hybridJobLogger,
-    repoBranchesRepo
+    repoBranchesRepo,
+    repoConnector
   );
   jobManager.start().catch((err) => {
     consoleLogger.error('App', `ERROR: ${err}`);

--- a/src/entities/job.ts
+++ b/src/entities/job.ts
@@ -6,6 +6,8 @@ export enum JobStatus {
   failed = 'failed',
 }
 
+// TODO: Restrict jobTypes, a la JobStatus
+
 export interface IJob {
   _id: string;
   payload: IPayload;
@@ -16,13 +18,11 @@ export interface IJob {
   priority: number | null | undefined;
   result: any | null | undefined;
   startTime: Date;
-  status: string;
+  status: JobStatus | null;
   title: string;
   user: string;
-  comMessage: string[] | null | undefined;
-  purgedUrls: string[] | null | undefined;
-  buildCommands: Array<string>;
-  deployCommands: Array<string>;
+  buildCommands: string[];
+  deployCommands: string[];
 }
 export interface IPayload {
   jobType: string;
@@ -63,18 +63,18 @@ export class BuildJob implements IJob {
   priority: number | null | undefined;
   result: any;
   startTime: Date;
-  status: string;
+  status: JobStatus | null;
   title: string;
   user: string;
+  buildCommands: string[];
+  deployCommands: string[];
   // BuildJob specific:
-  email: string; // probably vestigial
+  email: string; // probably can be removed
   comMessage: string[] | null | undefined;
   purgedUrls: string[] | null | undefined;
   manifestPrefix: string | undefined;
   pathPrefix: string | null | undefined;
   mutPrefix: string | null | undefined;
-  buildCommands: string[];
-  deployCommands: string[];
 }
 
 // ManifestJob represents the creation of the search manifest, which is kicked off
@@ -89,7 +89,16 @@ export class ManifestJob implements IJob {
   priority: number | null | undefined;
   result: any | null | undefined;
   startTime: Date;
-  status: string;
+  status: JobStatus | null;
   title: string;
   user: string;
+  buildCommands: string[];
+  deployCommands: string[];
 }
+
+export const jobMap = {
+  githubPush: BuildJob,
+  manifestGeneration: ManifestJob,
+  productionDeploy: BuildJob,
+  regression: BuildJob,
+};

--- a/src/entities/job.ts
+++ b/src/entities/job.ts
@@ -10,7 +10,6 @@ export interface IJob {
   _id: string;
   payload: IPayload;
   createdTime: Date;
-  email: string;
   endTime: Date | null | undefined;
   error: any | null | undefined;
   logs: string[] | null | undefined;
@@ -25,7 +24,6 @@ export interface IJob {
   buildCommands: Array<string>;
   deployCommands: Array<string>;
 }
-
 export interface IPayload {
   jobType: string;
   source: string;
@@ -55,11 +53,10 @@ export interface IPayload {
   includeInGlobalSearch: boolean;
 }
 
-export class Job implements IJob {
+export class BuildJob implements IJob {
   _id: string;
   payload: IPayload;
   createdTime: Date;
-  email: string;
   endTime: Date | null | undefined;
   error: any;
   logs: string[] | null | undefined;
@@ -69,6 +66,8 @@ export class Job implements IJob {
   status: string;
   title: string;
   user: string;
+  // BuildJob specific:
+  email: string; // probably vestigial
   comMessage: string[] | null | undefined;
   purgedUrls: string[] | null | undefined;
   manifestPrefix: string | undefined;
@@ -76,4 +75,21 @@ export class Job implements IJob {
   mutPrefix: string | null | undefined;
   buildCommands: string[];
   deployCommands: string[];
+}
+
+// ManifestJob represents the creation of the search manifest, which is kicked off
+// in the execute() function of JobHandler.
+export class ManifestJob implements IJob {
+  _id: string;
+  payload: IPayload;
+  createdTime: Date;
+  endTime: Date | null | undefined;
+  error: any | null | undefined;
+  logs: string[] | null | undefined;
+  priority: number | null | undefined;
+  result: any | null | undefined;
+  startTime: Date;
+  status: string;
+  title: string;
+  user: string;
 }

--- a/src/entities/queueMessage.ts
+++ b/src/entities/queueMessage.ts
@@ -1,4 +1,3 @@
-import { timingSafeEqual } from 'crypto';
 import { JobStatus } from './job';
 
 export class JobQueueMessage {

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -403,6 +403,7 @@ export abstract class JobHandler {
       await this.build();
       const resp = await this.deploy();
       await this.update(resp);
+      this.queueManifestJob();
       this.cleanup();
     } catch (error) {
       try {
@@ -411,6 +412,18 @@ export abstract class JobHandler {
       } catch (error) {
         this._logger.error(this._currJob._id, error.message);
       }
+    }
+  }
+
+  private async queueManifestJob(): Promise<void> {
+    try {
+      const manifestJob = {
+        // create manifest job here, with payload data
+      }
+      this._jobRepository.insertJob(manifestJob);
+    }
+    catch (error) {
+      this._logger.error(this._currJob._id, `Failed to build search manifest: ${error.message}`);
     }
   }
 

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -290,8 +290,10 @@ export abstract class JobHandler {
 
   protected abstract deploy(): Promise<CommandExecutorResponse>;
 
+  // TODO: Make this a non-mutating state function, e.g. return the deployCommands
   protected abstract prepDeployCommands(): void;
 
+  // TODO: Make this a non-mutating state function, e.g. return the buildCommands
   protected prepBuildCommands(): void {
     this.currJob.buildCommands = [
       `. /venv/bin/activate`,
@@ -353,6 +355,10 @@ export abstract class JobHandler {
     return await this.executeBuild();
   }
 
+  // TODO: Reduce complexity by not having individual child-class deploy() functions
+  // that just refer back to deployGeneric(), which itself leans is basically just a
+  // a wrapper for the command executor. E.g., the parent could call deployGeneric()
+  // itself, and then call the child's job-specific deploy()
   @throwIfJobInterupted()
   protected async deployGeneric(): Promise<CommandExecutorResponse> {
     this.prepDeployCommands();

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -50,7 +50,7 @@ export abstract class JobHandler {
     this._stopped = value;
   }
 
-  private _validator: IJobValidator;
+  private _jobValidator: IJobValidator;
 
   protected _config: IConfig;
 
@@ -65,10 +65,10 @@ export abstract class JobHandler {
     config: IConfig,
     fileSystemServices: IFileSystemServices,
     jobRepository: JobRepository,
+    jobValidator: IJobValidator,
     logger: IJobRepoLogger,
     repoBranchesRepo: RepoBranchesRepository,
-    repoConnector: IRepoConnector,
-    validator: IJobValidator
+    repoConnector: IRepoConnector
   ) {
     this._job = job;
     this._cdnConnector = cdnConnector;
@@ -76,10 +76,10 @@ export abstract class JobHandler {
     this._config = config;
     this._fileSystemServices = fileSystemServices;
     this._jobRepository = jobRepository;
+    this._jobValidator = jobValidator;
     this._logger = logger;
     this._repoBranchesRepo = repoBranchesRepo;
     this._repoConnector = repoConnector;
-    this._validator = validator;
 
     this._shouldStop = false;
   }
@@ -216,7 +216,7 @@ export abstract class JobHandler {
   @throwIfJobInterupted()
   private async prepNextGenBuild(): Promise<void> {
     if (this.isbuildNextGen()) {
-      await this._validator.throwIfBranchNotConfigured(this.job);
+      await this._jobValidator.throwIfBranchNotConfigured(this.job);
       await this.constructPrefix();
       // if this payload is NOT aliased or if it's the primary alias, we need the index path
       if (!this.job.payload.aliased || (this.job.payload.aliased && this.job.payload.primaryAlias)) {
@@ -227,7 +227,7 @@ export abstract class JobHandler {
       this.constructEnvVars();
       this.job.payload.isNextGen = true;
       if (this.jobType === 'productionDeploy') {
-        this._validator.throwIfNotPublishable(this.job);
+        this._jobValidator.throwIfNotPublishable(this.job);
       }
     } else {
       this.job.payload.isNextGen = false;
@@ -445,7 +445,7 @@ export abstract class JobHandler {
 }
 
 // Good to have this as a friend function
-function throwIfJobInterupted() {
+function throwIfJobInterupted(): any {
   return function decorator(descriptor: PropertyDescriptor) {
     const original = descriptor.value;
     if (typeof original === 'function') {

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -420,7 +420,7 @@ export abstract class JobHandler {
 
   private async queueManifestJob(): Promise<void> {
     // TODO: create new start time, id, etc.
-    const manifestJob = this.job || {}; // contains payload
+    const manifestJob = this.job; // contains payload - need to swap to ManifestJob type
     manifestJob.createdTime = new Date();
     // normal buildJobs have a priority of 1. Give a "lower" priority to manifest jobs
     manifestJob.priority = 2;
@@ -446,7 +446,7 @@ export abstract class JobHandler {
 
 // Good to have this as a friend function
 function throwIfJobInterupted() {
-  return function decorator(target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+  return function decorator(descriptor: PropertyDescriptor) {
     const original = descriptor.value;
     if (typeof original === 'function') {
       descriptor.value = function (...args) {

--- a/src/job/jobManager.ts
+++ b/src/job/jobManager.ts
@@ -1,17 +1,18 @@
-import { IJobValidator } from './jobValidator';
-import { ICDNConnector } from '../services/cdn';
+import { JobHandler } from './jobHandler';
+import { ManifestJobHandler } from './manifestJobHandler';
 import { ProductionJobHandler } from './productionJobHandler';
 import { RegressionJobHandler } from './regressionJobHandler';
 import { StagingJobHandler } from './stagingJobHandler';
-import { IRepoConnector } from '../services/repo';
-import { IJobRepoLogger } from '../services/logger';
-import { JobHandler } from './jobHandler';
-import { IJobCommandExecutor } from '../services/commandExecutor';
-import { InvalidJobError } from '../errors/errors';
-import { IJob } from '../entities/job';
-import { JobRepository } from '../repositories/jobRepository';
-import { IFileSystemServices } from '../services/fileServices';
+import { ICDNConnector } from '../services/cdn';
 import { IConfig } from 'config';
+import { IFileSystemServices } from '../services/fileServices';
+import { IJob } from '../entities/job';
+import { IJobCommandExecutor } from '../services/commandExecutor';
+import { IJobRepoLogger } from '../services/logger';
+import { IJobValidator } from './jobValidator';
+import { InvalidJobError } from '../errors/errors';
+import { IRepoConnector } from '../services/repo';
+import { JobRepository } from '../repositories/jobRepository';
 import { RepoBranchesRepository } from '../repositories/repoBranchesRepository';
 
 export class JobHandlerFactory {
@@ -27,47 +28,62 @@ export class JobHandlerFactory {
     validator: IJobValidator,
     repoBranchesRepo: RepoBranchesRepository
   ): JobHandler {
-    if (job.payload.jobType === 'regression') {
-      return new RegressionJobHandler(
-        job,
-        config,
-        jobRepository,
-        fileSystemServices,
-        commandExecutor,
-        cdnConnector,
-        repoConnector,
-        logger,
-        validator,
-        repoBranchesRepo
-      );
-    } else if (job.payload.jobType === 'githubPush') {
-      return new StagingJobHandler(
-        job,
-        config,
-        jobRepository,
-        fileSystemServices,
-        commandExecutor,
-        cdnConnector,
-        repoConnector,
-        logger,
-        validator,
-        repoBranchesRepo
-      );
-    } else if (job.payload.jobType === 'productionDeploy') {
-      return new ProductionJobHandler(
-        job,
-        config,
-        jobRepository,
-        fileSystemServices,
-        commandExecutor,
-        cdnConnector,
-        repoConnector,
-        logger,
-        validator,
-        repoBranchesRepo
-      );
+    switch (job.payload?.jobType) {
+      case 'regression':
+        return new RegressionJobHandler(
+          job,
+          config,
+          jobRepository,
+          fileSystemServices,
+          commandExecutor,
+          cdnConnector,
+          repoConnector,
+          logger,
+          validator,
+          repoBranchesRepo
+        );
+      case 'githubPush':
+        return new StagingJobHandler(
+          job,
+          config,
+          jobRepository,
+          fileSystemServices,
+          commandExecutor,
+          cdnConnector,
+          repoConnector,
+          logger,
+          validator,
+          repoBranchesRepo
+        );
+      case 'productionDeploy':
+        return new ProductionJobHandler(
+          job,
+          config,
+          jobRepository,
+          fileSystemServices,
+          commandExecutor,
+          cdnConnector,
+          repoConnector,
+          logger,
+          validator,
+          repoBranchesRepo
+        );
+      case 'manifestGeneration':
+        return new ManifestJobHandler(
+          job,
+          config,
+          jobRepository,
+          fileSystemServices,
+          commandExecutor,
+          cdnConnector,
+          repoConnector,
+          logger,
+          validator,
+          repoBranchesRepo
+        );
+      default:
+        throw new InvalidJobError(`Job type '${job.payload?.jobType}' not supported`);
     }
-    throw new InvalidJobError('Job type not supported');
   }
 }
 

--- a/src/job/manifestJobHandler.ts
+++ b/src/job/manifestJobHandler.ts
@@ -1,0 +1,60 @@
+import { JobHandler } from './jobHandler';
+import { IConfig } from 'config';
+import { IJob } from '../entities/job';
+import { JobRepository } from '../repositories/jobRepository';
+import { ICDNConnector } from '../services/cdn';
+import { CommandExecutorResponse, IJobCommandExecutor } from '../services/commandExecutor';
+import { IFileSystemServices } from '../services/fileServices';
+import { IJobRepoLogger } from '../services/logger';
+import { IRepoConnector } from '../services/repo';
+import { IJobValidator } from './jobValidator';
+import { RepoBranchesRepository } from '../repositories/repoBranchesRepository';
+
+export class ManifestJobHandler extends JobHandler {
+  constructor(
+    job: IJob,
+    config: IConfig,
+    jobRepository: JobRepository,
+    fileSystemServices: IFileSystemServices,
+    commandExecutor: IJobCommandExecutor,
+    cdnConnector: ICDNConnector,
+    repoConnector: IRepoConnector,
+    logger: IJobRepoLogger,
+    validator: IJobValidator,
+    repoBranchesRepo: RepoBranchesRepository
+  ) {
+    super(
+      job,
+      config,
+      jobRepository,
+      fileSystemServices,
+      commandExecutor,
+      cdnConnector,
+      repoConnector,
+      logger,
+      validator,
+      repoBranchesRepo
+    );
+    this.name = 'Manifest';
+  }
+
+  // TODO: Make this a non-mutating state function, e.g. return the deployCommands
+  prepDeployCommands(): void {
+    this.currJob.deployCommands = ['. /venv/bin/activate', `cd repos/${this.currJob.payload.repoName}`, 'echo mock generate manifest'];
+  }
+
+  prepStageSpecificNextGenCommands(): void {
+    return;
+  }
+
+  async deploy(): Promise<CommandExecutorResponse> {
+    try {
+      const resp = await this.deployGeneric();
+      await this.logger.save(this.currJob._id, `(generate manifest) Manifest generation details:\n\n${resp?.output}`);
+      return resp;
+    } catch (errResult) {
+      await this.logger.save(this.currJob._id, `(generate manifest) stdErr: ${errResult.stderr}`);
+      throw errResult;
+    }
+  }
+}

--- a/src/job/manifestJobHandler.ts
+++ b/src/job/manifestJobHandler.ts
@@ -14,26 +14,26 @@ export class ManifestJobHandler extends JobHandler {
   constructor(
     job: ManifestJob,
     cdnConnector: ICDNConnector,
-    commandExecutor: IJobCommandExecutor,
     config: IConfig,
     fileSystemServices: IFileSystemServices,
+    jobCommandExecutor: IJobCommandExecutor,
     jobRepository: JobRepository,
+    jobValidator: IJobValidator,
     logger: IJobRepoLogger,
     repoBranchesRepo: RepoBranchesRepository,
-    repoConnector: IRepoConnector,
-    validator: IJobValidator
+    repoConnector: IRepoConnector
   ) {
     super(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepository,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     this.name = 'Manifest';
   }

--- a/src/job/manifestJobHandler.ts
+++ b/src/job/manifestJobHandler.ts
@@ -38,7 +38,7 @@ export class ManifestJobHandler extends JobHandler {
     this.name = 'Manifest';
   }
 
-  // TODO: Make this a non-mutating state function, e.g. return the deployCommands
+  // TODO: Make this a non-state-mutating function, e.g. return the deployCommands?
   prepDeployCommands(): void {
     this.currJob.deployCommands = ['. /venv/bin/activate', `cd repos/${this.currJob.payload.repoName}`, 'echo mock generate manifest'];
   }

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -16,26 +16,26 @@ export class ProductionJobHandler extends JobHandler {
   constructor(
     job: BuildJob,
     cdnConnector: ICDNConnector,
-    commandExecutor: IJobCommandExecutor,
     config: IConfig,
     fileSystemServices: IFileSystemServices,
+    jobCommandExecutor: IJobCommandExecutor,
     jobRepository: JobRepository,
+    jobValidator: IJobValidator,
     logger: IJobRepoLogger,
     repoBranchesRepo: RepoBranchesRepository,
-    repoConnector: IRepoConnector,
-    validator: IJobValidator
+    repoConnector: IRepoConnector
   ) {
     super(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepository,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     this.name = 'Production';
   }

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -1,6 +1,6 @@
 import { IConfig } from 'config';
 import { CDNCreds } from '../entities/creds';
-import { IJob } from '../entities/job';
+import { IJob, IPayload } from '../entities/job';
 import { InvalidJobError } from '../errors/errors';
 import { JobRepository } from '../repositories/jobRepository';
 import { RepoBranchesRepository } from '../repositories/repoBranchesRepository';
@@ -48,10 +48,11 @@ export class ProductionJobHandler extends JobHandler {
     ];
 
     if (this.currJob.payload.isNextGen) {
-      const manifestPrefix = this.currJob.payload.manifestPrefix;
       this.currJob.deployCommands[
         this.currJob.deployCommands.length - 1
       ] = `make next-gen-deploy MUT_PREFIX=${this.currJob.payload.mutPrefix}`;
+      // TODO: Remove functionality of manifestPrefix
+      const manifestPrefix = this.currJob.payload.manifestPrefix;
       if (manifestPrefix) {
         const searchFlag = this.currJob.payload.stable;
         this.currJob.deployCommands[
@@ -120,8 +121,8 @@ export class ProductionJobHandler extends JobHandler {
   }
 
   async deploy(): Promise<CommandExecutorResponse> {
-    const resp = await this.deployGeneric();
     try {
+      const resp = await this.deployGeneric();
       if (resp?.output) {
         const makefileOutput = resp.output.replace(/\r/g, '').split(/\n/);
         await this.purgePublishedContent(makefileOutput);

--- a/src/job/regressionJobHandler.ts
+++ b/src/job/regressionJobHandler.ts
@@ -1,5 +1,5 @@
 import { IConfig } from 'config';
-import { IJob } from '../entities/job';
+import { BuildJob } from '../entities/job';
 import { JobRepository } from '../repositories/jobRepository';
 import { RepoBranchesRepository } from '../repositories/repoBranchesRepository';
 import { ICDNConnector } from '../services/cdn';
@@ -12,28 +12,28 @@ import { ProductionJobHandler } from './productionJobHandler';
 
 export class RegressionJobHandler extends ProductionJobHandler {
   constructor(
-    job: IJob,
-    config: IConfig,
-    jobRepository: JobRepository,
-    fileSystemServices: IFileSystemServices,
-    commandExecutor: IJobCommandExecutor,
+    job: BuildJob,
     cdnConnector: ICDNConnector,
-    repoConnector: IRepoConnector,
+    commandExecutor: IJobCommandExecutor,
+    config: IConfig,
+    fileSystemServices: IFileSystemServices,
+    jobRepository: JobRepository,
     logger: IJobRepoLogger,
-    validator: IJobValidator,
-    repoBranchesRepo: RepoBranchesRepository
+    repoBranchesRepo: RepoBranchesRepository,
+    repoConnector: IRepoConnector,
+    validator: IJobValidator
   ) {
     super(
       job,
-      config,
-      jobRepository,
-      fileSystemServices,
-      commandExecutor,
       cdnConnector,
-      repoConnector,
+      commandExecutor,
+      config,
+      fileSystemServices,
+      jobRepository,
       logger,
-      validator,
-      repoBranchesRepo
+      repoBranchesRepo,
+      repoConnector,
+      validator
     );
     this.name = 'Regression';
   }

--- a/src/job/regressionJobHandler.ts
+++ b/src/job/regressionJobHandler.ts
@@ -14,26 +14,26 @@ export class RegressionJobHandler extends ProductionJobHandler {
   constructor(
     job: BuildJob,
     cdnConnector: ICDNConnector,
-    commandExecutor: IJobCommandExecutor,
     config: IConfig,
     fileSystemServices: IFileSystemServices,
+    jobCommandExecutor: IJobCommandExecutor,
     jobRepository: JobRepository,
+    jobValidator: IJobValidator,
     logger: IJobRepoLogger,
     repoBranchesRepo: RepoBranchesRepository,
-    repoConnector: IRepoConnector,
-    validator: IJobValidator
+    repoConnector: IRepoConnector
   ) {
     super(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepository,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     this.name = 'Regression';
   }

--- a/src/job/stagingJobHandler.ts
+++ b/src/job/stagingJobHandler.ts
@@ -14,26 +14,26 @@ export class StagingJobHandler extends JobHandler {
   constructor(
     job: BuildJob,
     cdnConnector: ICDNConnector,
-    commandExecutor: IJobCommandExecutor,
     config: IConfig,
     fileSystemServices: IFileSystemServices,
+    jobCommandExecutor: IJobCommandExecutor,
     jobRepository: JobRepository,
+    jobValidator: IJobValidator,
     logger: IJobRepoLogger,
     repoBranchesRepo: RepoBranchesRepository,
-    repoConnector: IRepoConnector,
-    validator: IJobValidator
+    repoConnector: IRepoConnector
   ) {
     super(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepository,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     this.name = 'Staging';
   }

--- a/src/repositories/baseRepository.ts
+++ b/src/repositories/baseRepository.ts
@@ -66,12 +66,12 @@ export abstract class BaseRepository {
     try {
       const updateResult = await this.update(query, update, errorMsg);
       if ((updateResult?.modifiedCount ?? 0) < 1) {
-        throw new DBError(`Failed to update (${JSON.stringify(query)})  for ${JSON.stringify(update)}`);
+        throw new DBError(`Failed to update (${JSON.stringify(query)}) for ${JSON.stringify(update)}`);
       }
     } catch (error) {
       this._logger.error(
         `${this._repoName}:updateOne`,
-        `Failed to update  (${JSON.stringify(query)})  for ${JSON.stringify(update)} Error: ${error.message}`
+        `Failed to update  (${JSON.stringify(query)}) for ${JSON.stringify(update)} Error: ${error.message}`
       );
       throw error;
     }
@@ -87,7 +87,7 @@ export abstract class BaseRepository {
     } catch (error) {
       this._logger.error(
         `${this._repoName}:findOneAndUpdate`,
-        `Failed to findOneAndUpdate (${JSON.stringify(query)})  for ${JSON.stringify(
+        `Failed to findOneAndUpdate (${JSON.stringify(query)}) for ${JSON.stringify(
           update
         )} with options ${JSON.stringify(options)} error: ${error}`
       );

--- a/src/repositories/repoBranchesRepository.ts
+++ b/src/repositories/repoBranchesRepository.ts
@@ -1,6 +1,5 @@
 import { Db } from 'mongodb';
 import { BaseRepository } from './baseRepository';
-import { Job } from '../entities/job';
 import { ILogger } from '../services/logger';
 import { IConfig } from 'config';
 

--- a/src/repositories/repoEntitlementsRepository.ts
+++ b/src/repositories/repoEntitlementsRepository.ts
@@ -1,6 +1,6 @@
 import { Db } from 'mongodb';
 import { BaseRepository } from './baseRepository';
-gimport { ILogger } from '../services/logger';
+import { ILogger } from '../services/logger';
 import { IConfig } from 'config';
 
 export class RepoEntitlementsRepository extends BaseRepository {

--- a/src/repositories/repoEntitlementsRepository.ts
+++ b/src/repositories/repoEntitlementsRepository.ts
@@ -1,7 +1,6 @@
 import { Db } from 'mongodb';
 import { BaseRepository } from './baseRepository';
-import { Job } from '../entities/job';
-import { ILogger } from '../services/logger';
+gimport { ILogger } from '../services/logger';
 import { IConfig } from 'config';
 
 export class RepoEntitlementsRepository extends BaseRepository {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -110,6 +110,7 @@ export class SlackConnector implements ISlackConnector {
     });
   }
 
+  // TODO: Give users to generate manifest with deploy?
   private _getDropDownView(triggerId: string, repos: Array<any>) {
     return {
       trigger_id: triggerId,

--- a/tests/unit/job/JobHandlerFactory.test.ts
+++ b/tests/unit/job/JobHandlerFactory.test.ts
@@ -12,29 +12,30 @@ import { ProductionJobHandler } from '../../../src/job/productionJobHandler';
 import { RegressionJobHandler } from '../../../src/job/regressionJobHandler';
 import { StagingJobHandler } from '../../../src/job/stagingJobHandler';
 import { RepoBranchesRepository } from '../../../src/repositories/repoBranchesRepository';
-import { IJobValidator } from '../../../src/job/jobValidator';
+import { IJobValidator, JobValidator } from '../../../src/job/jobValidator';
 
 describe('JobHandlerFactory Tests', () => {
   let job: IJob;
   let cdnConnector: ICDNConnector;
-  let commandExecutor: IJobCommandExecutor;
   let config: IConfig;
   let fileSystemServices: IFileSystemServices;
+  let jobCommandExecutor: IJobCommandExecutor;
   let jobHandlerFactory: JobHandlerFactory;
   let jobRepo: JobRepository;
+  let jobValidator: IJobValidator;
   let logger: IJobRepoLogger;
   let repoBranchesRepo: RepoBranchesRepository;
   let repoConnector: IRepoConnector;
-  let validator: IJobValidator;
 
   beforeEach(() => {
     job = mockDeep<IJob>();
     cdnConnector = mockDeep<ICDNConnector>();
-    commandExecutor = mockDeep<IJobCommandExecutor>();
     config = mockDeep<IConfig>();
     fileSystemServices = mockDeep<IFileSystemServices>();
+    jobCommandExecutor = mockDeep<IJobCommandExecutor>();
     jobHandlerFactory = new JobHandlerFactory();
     jobRepo = mockDeep<JobRepository>();
+    jobValidator = mockDeep<JobValidator>();
     logger = mockDeep<IJobRepoLogger>();
     repoBranchesRepo = mockDeep<RepoBranchesRepository>();
     repoConnector = mockDeep<IRepoConnector>();
@@ -50,14 +51,14 @@ describe('JobHandlerFactory Tests', () => {
       jobHandlerFactory.createJobHandler(
         job,
         cdnConnector,
-        commandExecutor,
         config,
         fileSystemServices,
+        jobCommandExecutor,
         jobRepo,
+        jobValidator,
         logger,
         repoBranchesRepo,
-        repoConnector,
-        validator
+        repoConnector
       );
     }).toThrowError(`Job type 'Unknown' not supported`);
   });
@@ -67,14 +68,14 @@ describe('JobHandlerFactory Tests', () => {
     const handler = jobHandlerFactory.createJobHandler(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepo,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     expect(handler).toBeInstanceOf(RegressionJobHandler);
   });
@@ -84,14 +85,14 @@ describe('JobHandlerFactory Tests', () => {
     const handler = jobHandlerFactory.createJobHandler(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepo,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     expect(handler).toBeInstanceOf(StagingJobHandler);
   });
@@ -101,14 +102,14 @@ describe('JobHandlerFactory Tests', () => {
     const handler = jobHandlerFactory.createJobHandler(
       job,
       cdnConnector,
-      commandExecutor,
       config,
       fileSystemServices,
+      jobCommandExecutor,
       jobRepo,
+      jobValidator,
       logger,
       repoBranchesRepo,
-      repoConnector,
-      validator
+      repoConnector
     );
     expect(handler).toBeInstanceOf(ProductionJobHandler);
   });

--- a/tests/unit/job/JobHandlerFactory.test.ts
+++ b/tests/unit/job/JobHandlerFactory.test.ts
@@ -59,7 +59,7 @@ describe('JobHandlerFactory Tests', () => {
         jobValidator,
         repoBranchesRepo
       );
-    }).toThrowError('Job type not supported');
+    }).toThrowError(`Job type 'Unknown' not supported`);
   });
 
   test('regression jobtype returns regression handler', () => {

--- a/tests/unit/job/JobHandlerFactory.test.ts
+++ b/tests/unit/job/JobHandlerFactory.test.ts
@@ -16,28 +16,28 @@ import { IJobValidator } from '../../../src/job/jobValidator';
 
 describe('JobHandlerFactory Tests', () => {
   let job: IJob;
-  let config: IConfig;
-  let jobRepo: JobRepository;
-  let fileSystemServices: IFileSystemServices;
-  let jobCommandExecutor: IJobCommandExecutor;
   let cdnConnector: ICDNConnector;
-  let repoConnector: IRepoConnector;
-  let logger: IJobRepoLogger;
+  let commandExecutor: IJobCommandExecutor;
+  let config: IConfig;
+  let fileSystemServices: IFileSystemServices;
   let jobHandlerFactory: JobHandlerFactory;
+  let jobRepo: JobRepository;
+  let logger: IJobRepoLogger;
   let repoBranchesRepo: RepoBranchesRepository;
-  let jobValidator: IJobValidator;
+  let repoConnector: IRepoConnector;
+  let validator: IJobValidator;
 
   beforeEach(() => {
     job = mockDeep<IJob>();
-    config = mockDeep<IConfig>();
-    jobRepo = mockDeep<JobRepository>();
-    fileSystemServices = mockDeep<IFileSystemServices>();
-    jobCommandExecutor = mockDeep<IJobCommandExecutor>();
     cdnConnector = mockDeep<ICDNConnector>();
-    repoConnector = mockDeep<IRepoConnector>();
-    logger = mockDeep<IJobRepoLogger>();
+    commandExecutor = mockDeep<IJobCommandExecutor>();
+    config = mockDeep<IConfig>();
+    fileSystemServices = mockDeep<IFileSystemServices>();
     jobHandlerFactory = new JobHandlerFactory();
+    jobRepo = mockDeep<JobRepository>();
+    logger = mockDeep<IJobRepoLogger>();
     repoBranchesRepo = mockDeep<RepoBranchesRepository>();
+    repoConnector = mockDeep<IRepoConnector>();
   });
 
   test('Construct Job Factory', () => {
@@ -49,15 +49,15 @@ describe('JobHandlerFactory Tests', () => {
     expect(() => {
       jobHandlerFactory.createJobHandler(
         job,
-        config,
-        jobRepo,
-        fileSystemServices,
-        jobCommandExecutor,
         cdnConnector,
-        repoConnector,
+        commandExecutor,
+        config,
+        fileSystemServices,
+        jobRepo,
         logger,
-        jobValidator,
-        repoBranchesRepo
+        repoBranchesRepo,
+        repoConnector,
+        validator
       );
     }).toThrowError(`Job type 'Unknown' not supported`);
   });
@@ -66,15 +66,15 @@ describe('JobHandlerFactory Tests', () => {
     job.payload.jobType = 'regression';
     const handler = jobHandlerFactory.createJobHandler(
       job,
-      config,
-      jobRepo,
-      fileSystemServices,
-      jobCommandExecutor,
       cdnConnector,
-      repoConnector,
+      commandExecutor,
+      config,
+      fileSystemServices,
+      jobRepo,
       logger,
-      jobValidator,
-      repoBranchesRepo
+      repoBranchesRepo,
+      repoConnector,
+      validator
     );
     expect(handler).toBeInstanceOf(RegressionJobHandler);
   });
@@ -83,15 +83,15 @@ describe('JobHandlerFactory Tests', () => {
     job.payload.jobType = 'githubPush';
     const handler = jobHandlerFactory.createJobHandler(
       job,
-      config,
-      jobRepo,
-      fileSystemServices,
-      jobCommandExecutor,
       cdnConnector,
-      repoConnector,
+      commandExecutor,
+      config,
+      fileSystemServices,
+      jobRepo,
       logger,
-      jobValidator,
-      repoBranchesRepo
+      repoBranchesRepo,
+      repoConnector,
+      validator
     );
     expect(handler).toBeInstanceOf(StagingJobHandler);
   });
@@ -100,15 +100,15 @@ describe('JobHandlerFactory Tests', () => {
     job.payload.jobType = 'productionDeploy';
     const handler = jobHandlerFactory.createJobHandler(
       job,
-      config,
-      jobRepo,
-      fileSystemServices,
-      jobCommandExecutor,
       cdnConnector,
-      repoConnector,
+      commandExecutor,
+      config,
+      fileSystemServices,
+      jobRepo,
       logger,
-      jobValidator,
-      repoBranchesRepo
+      repoBranchesRepo,
+      repoConnector,
+      validator
     );
     expect(handler).toBeInstanceOf(ProductionJobHandler);
   });

--- a/tests/unit/job/manifestJobHandler.test.ts
+++ b/tests/unit/job/manifestJobHandler.test.ts
@@ -1,0 +1,101 @@
+import { TestDataProvider } from '../../data/data';
+import { JobHandlerTestHelper } from '../../utils/jobHandlerTestHelper';
+
+describe('StagingJobHandler Tests', () => {
+  let jobHandlerTestHelper: JobHandlerTestHelper;
+
+  beforeEach(() => {
+    jobHandlerTestHelper = new JobHandlerTestHelper();
+    jobHandlerTestHelper.init('staging');
+  });
+
+  test('Construct Production Handler', () => {
+    expect(jobHandlerTestHelper.jobHandler).toBeDefined();
+  });
+
+  test('Execute called after a stop signal throws error Production Handler at decorator', () => {
+    jobHandlerTestHelper.jobHandler.stop();
+    expect(() => {
+      jobHandlerTestHelper.jobHandler.execute();
+    }).toThrow(`${jobHandlerTestHelper.job._id} is stopped`);
+  });
+
+  test('Execute legacy build runs successfully', async () => {
+    jobHandlerTestHelper.setStageForDeploySuccess(false, false);
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(false);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getCommonBuildCommands(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.job.deployCommands).toEqual(
+      TestDataProvider.getCommonDeployCommandsForStaging(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);
+    expect(jobHandlerTestHelper.cdnConnector.purge).toHaveBeenCalledTimes(0);
+    expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toHaveBeenCalledTimes(0);
+  });
+
+  test('Execute nextgen build runs successfully without path prefix', async () => {
+    jobHandlerTestHelper.setStageForDeploySuccess(true, false);
+    jobHandlerTestHelper.config.get.calledWith('shouldPurgeAll').mockReturnValue(true);
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getExpectedStagingBuildNextGenCommands(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.job.deployCommands).toEqual(
+      TestDataProvider.getExpectedStageDeployNextGenCommands(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);
+    expect(jobHandlerTestHelper.cdnConnector.purge).toHaveBeenCalledTimes(0);
+    expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toHaveBeenCalledTimes(0);
+  });
+
+  test('Execute nextgen build runs successfully with pathprefix', async () => {
+    jobHandlerTestHelper.setStageForDeploySuccess(true, false);
+    jobHandlerTestHelper.config.get.calledWith('shouldPurgeAll').mockReturnValue(true);
+    jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
+    jobHandlerTestHelper.job.payload.pathPrefix = 'Mutprefix';
+    jobHandlerTestHelper.job.payload.mutPrefix = 'Mutprefix';
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getExpectedStagingBuildNextGenCommands(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.job.deployCommands).toEqual(
+      TestDataProvider.getExpectedStageDeployNextGenCommands(jobHandlerTestHelper.job)
+    );
+  });
+
+  test('Execute nextgen build runs successfully for devhub integration', async () => {
+    jobHandlerTestHelper.job.payload.repoName = 'devhub-content-integration';
+    jobHandlerTestHelper.setStageForDeploySuccess(true, false);
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getExpectedStagingBuildNextGenCommands(jobHandlerTestHelper.job)
+    );
+  });
+
+  test('Execute nextgen build runs successfully and results in summary message', async () => {
+    jobHandlerTestHelper.setStageForDeploySuccess(true, false);
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getExpectedStagingBuildNextGenCommands(jobHandlerTestHelper.job)
+    );
+    expect(jobHandlerTestHelper.jobRepo.insertNotificationMessages).toBeCalledWith(
+      jobHandlerTestHelper.job._id,
+      'Summary: All good'
+    );
+  });
+
+  test('Execute nextgen build deploy throws error updates the job with correct error message', async () => {
+    jobHandlerTestHelper.setStageForDeployFailure(null, 'ERROR:BAD ONE');
+    await jobHandlerTestHelper.jobHandler.execute();
+    expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
+    expect(jobHandlerTestHelper.job.buildCommands).toEqual(
+      TestDataProvider.getExpectedStagingBuildNextGenCommands(jobHandlerTestHelper.job)
+    );
+  });
+});

--- a/tests/unit/repositories/jobRepository.test.ts
+++ b/tests/unit/repositories/jobRepository.test.ts
@@ -24,7 +24,7 @@ describe('Job Repository Tests', () => {
         new Date()
       );
       await expect(jobRepo.updateWithCompletionStatus('Test_Job', 'All good')).rejects.toThrow(
-        `Failed to update job (${JSON.stringify(testData.query)})  for ${JSON.stringify(testData.update)}`
+        `Failed to update (${JSON.stringify(testData.query)}) for ${JSON.stringify(testData.update)}`
       );
     });
 
@@ -37,7 +37,7 @@ describe('Job Repository Tests', () => {
       );
       dbRepoHelper.collection.updateOne.mockReturnValue({ modifiedCount: -1 });
       await expect(jobRepo.updateWithCompletionStatus('Test_Job', 'All good')).rejects.toThrow(
-        `Failed to update job (${JSON.stringify(testData.query)})  for ${JSON.stringify(testData.update)}`
+        `Failed to update (${JSON.stringify(testData.query)}) for ${JSON.stringify(testData.update)}`
       );
       expect(dbRepoHelper.collection.updateOne).toBeCalledTimes(1);
     });
@@ -51,7 +51,7 @@ describe('Job Repository Tests', () => {
       );
       dbRepoHelper.collection.updateOne.mockReturnValueOnce({ result: { sn: -1 } });
       await expect(jobRepo.updateWithCompletionStatus('Test_Job', 'All good')).rejects.toThrow(
-        `Failed to update job (${JSON.stringify(testData.query)})  for ${JSON.stringify(testData.update)}`
+        `Failed to update (${JSON.stringify(testData.query)}) for ${JSON.stringify(testData.update)}`
       );
       expect(dbRepoHelper.collection.updateOne).toBeCalledTimes(1);
       expect(dbRepoHelper.logger.error).toBeCalledTimes(1);

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -1,31 +1,31 @@
 import { IConfig } from 'config';
 import { mockDeep } from 'jest-mock-extended';
-import { IJob } from '../../src/entities/job';
-import { IJobValidator } from '../../src/job/jobValidator';
-import { ProductionJobHandler } from '../../src/job/productionJobHandler';
-import { StagingJobHandler } from '../../src/job/stagingJobHandler';
-import { JobRepository } from '../../src/repositories/jobRepository';
-import { RepoBranchesRepository } from '../../src/repositories/repoBranchesRepository';
 import { ICDNConnector } from '../../src/services/cdn';
-import { IJobCommandExecutor } from '../../src/services/commandExecutor';
 import { IFileSystemServices } from '../../src/services/fileServices';
+import { IJob } from '../../src/entities/job';
+import { IJobCommandExecutor } from '../../src/services/commandExecutor';
 import { IJobRepoLogger } from '../../src/services/logger';
+import { IJobValidator } from '../../src/job/jobValidator';
 import { IRepoConnector } from '../../src/services/repo';
+import { JobRepository } from '../../src/repositories/jobRepository';
+import { ProductionJobHandler } from '../../src/job/productionJobHandler';
+import { RepoBranchesRepository } from '../../src/repositories/repoBranchesRepository';
+import { StagingJobHandler } from '../../src/job/stagingJobHandler';
 import { TestDataProvider } from '../data/data';
 import * as data from '../data/jobDef';
 
 export class JobHandlerTestHelper {
   job: IJob;
+  cdnConnector: ICDNConnector;
   config: IConfig;
-  jobRepo: JobRepository;
   fileSystemServices: IFileSystemServices;
   jobCommandExecutor: IJobCommandExecutor;
-  cdnConnector: ICDNConnector;
-  repoConnector: IRepoConnector;
-  logger: IJobRepoLogger;
   jobHandler: ProductionJobHandler | StagingJobHandler;
+  jobRepo: JobRepository;
   jobValidator: IJobValidator;
+  logger: IJobRepoLogger;
   repoBranchesRepo: RepoBranchesRepository;
+  repoConnector: IRepoConnector;
   lengthPrototype;
   handlerMapper = {
     prod: ProductionJobHandler,
@@ -34,26 +34,26 @@ export class JobHandlerTestHelper {
 
   init(handlerName: string): ProductionJobHandler | StagingJobHandler {
     this.job = JSON.parse(JSON.stringify(data.default.value));
+    this.cdnConnector = mockDeep<ICDNConnector>();
     this.config = mockDeep<IConfig>();
-    this.jobRepo = mockDeep<JobRepository>();
     this.fileSystemServices = mockDeep<IFileSystemServices>();
     this.jobCommandExecutor = mockDeep<IJobCommandExecutor>();
-    this.cdnConnector = mockDeep<ICDNConnector>();
-    this.repoConnector = mockDeep<IRepoConnector>();
-    this.logger = mockDeep<IJobRepoLogger>();
+    this.jobRepo = mockDeep<JobRepository>();
     this.jobValidator = mockDeep<IJobValidator>();
+    this.logger = mockDeep<IJobRepoLogger>();
     this.repoBranchesRepo = mockDeep<RepoBranchesRepository>();
+    this.repoConnector = mockDeep<IRepoConnector>();
     this.jobHandler = new this.handlerMapper[handlerName](
       this.job,
+      this.cdnConnector,
       this.config,
-      this.jobRepo,
       this.fileSystemServices,
       this.jobCommandExecutor,
-      this.cdnConnector,
-      this.repoConnector,
-      this.logger,
+      this.jobRepo,
       this.jobValidator,
-      this.repoBranchesRepo
+      this.logger,
+      this.repoBranchesRepo,
+      this.repoConnector
     );
     return this.jobHandler;
   }


### PR DESCRIPTION
POC manifest generation infrastructure changes without Amazon SQS.

- Creates a new `BuildJob` and `ManifestJob` to differentiate the two
- Changes many instances of `IJob` type to `Build Job | ManifestJob`
- Adds new `ManifestJobHandler` that simply prints proof via `echo`
- NO CHANGE to current manifest generation process via Makefiles, preserved until it can be replaced

Also:
- standardizes some notation (e.g. `currJob` -> `job`, `fullDocument` -> `job`, alphabetizes handler instantiation)
- Adds and changes some types to further cut down on lint warnings
- Removes unused code