### PR TITLE
(DOCSP-20655): Updating the mcli version flipper for v1.22.0

### DIFF
--- a/publishedbranches/docs-mongocli.yaml
+++ b/publishedbranches/docs-mongocli.yaml
@@ -1,8 +1,9 @@
 prefix: 'mongocli'
 version:
   published:
-    - '1.22 (upcoming)'
-    - '1.21 (stable)'
+    - '1.23 (upcoming)'
+    - '1.22 (stable)'
+    - '1.21'
     - '1.20'
     - '1.19'
     - '1.18'
@@ -30,8 +31,9 @@ version:
     - '0.0.4'
     - '0.0.3'
   active:
-    - '1.22 (upcoming)'
-    - '1.21 (stable)'
+    - '1.23 (upcoming)'
+    - '1.22 (stable)'
+    - '1.21'
     - '1.20'
     - '1.19'
     - '1.18'
@@ -53,13 +55,14 @@ version:
     - '1.2'
     - '1.1'
     - '1.0'
-  stable: 'v1.21'
-  upcoming: 'v1.22'
+  stable: 'v1.22'
+  upcoming: 'v1.23'
 git:
   branches:
     manual: 'master'
     published:
       - 'master'
+      - 'v1.22'
       - 'v1.21'
       - 'v1.20'
       - 'v1.19'


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-20655)