### PR TITLE
DOP-2780: Add REPO_NAME to docs and docs-mongodb-internal

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -4,6 +4,7 @@ USER=$(shell whoami)
 
 PREFIX=manual
 PROJECT=docs
+REPO_NAME=docs
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
@@ -58,6 +59,7 @@ next-gen-html: examples get-build-dependencies
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
+	echo "REPO_NAME=${REPO_NAME}" >> .env.production; \
 	if [ -n "${PATCH_ID}" ]; then \
 		echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production && \
 		echo "PATCH_ID=${PATCH_ID}" >> .env.production; \

--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -7,6 +7,7 @@ else
 endif
 
 PROJECT=docs
+REPO_NAME=docs-mongodb-internal
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
@@ -43,6 +44,7 @@ next-gen-html: examples get-build-dependencies
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
+	echo "REPO_NAME=${REPO_NAME}" >> .env.production; \
 	if [ -n "${PATCH_ID}" ]; then \
 		echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production && \
 		echo "PATCH_ID=${PATCH_ID}" >> .env.production; \


### PR DESCRIPTION
Passes in `REPO_NAME` as env variable to frontend for `docs` and `docs-mongodb-internal` only. This is to differentiate the two repos when fetching their versions/branches on the frontend, while maintaining the same project names for both. This change *should* be backwards compatible and not cause any disruption in docs team workflow since the frontend currently doesn't do anything with this env variable.

If things look good here, I can commit the same changes directly to the `DOP-2747-meta` and `DOP-2747-meta-stg` branches.