### PR TITLE
DOP-2788: Set PATH_PREFIX env variable to '/' for deploys to bucket root

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -66,3 +66,8 @@ jobs:
           npm ci
           sls deploy --stage stg
           sls deploy --stage dotcomstg
+      - name: Deploy Lambdas	
+        run: |
+          npm ci          
+          sls deploy --stage stg
+          sls deploy --stage dotcomstg

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -66,9 +66,3 @@ jobs:
           npm ci
           sls deploy --stage stg
           sls deploy --stage dotcomstg
-
-      - name: Deploy Lambdas
-        run: |
-          npm ci
-          sls deploy --stage stg
-          sls deploy --stage dotcomstg

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -276,7 +276,6 @@ export abstract class JobHandler {
     for (const [envName, envValue] of Object.entries(snootyFrontEndVars)) {
       if (envValue) envVars += `${envName}=${envValue}\n`;
     }
-    envVars = envVars.trim();
     this._fileSystemServices.writeToFile(`repos/${this.currJob.payload.repoName}/.env.production`, envVars, {
       encoding: 'utf8',
       flag: 'w',

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -119,8 +119,6 @@ export abstract class JobHandler {
   private async constructPrefix(): Promise<void> {
     const server_user = this._config.get<string>('GATSBY_PARSER_USER');
     const pathPrefix = await this.getPathPrefix();
-    console.log('jobHandler hello world');
-    console.log(pathPrefix);
     // TODO: Can empty string check be removed?
     if (pathPrefix || pathPrefix === '') {
       this.currJob.payload.pathPrefix = pathPrefix;

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -119,6 +119,8 @@ export abstract class JobHandler {
   private async constructPrefix(): Promise<void> {
     const server_user = this._config.get<string>('GATSBY_PARSER_USER');
     const pathPrefix = await this.getPathPrefix();
+    console.log('jobHandler hello world');
+    console.log(pathPrefix);
     // TODO: Can empty string check be removed?
     if (pathPrefix || pathPrefix === '') {
       this.currJob.payload.pathPrefix = pathPrefix;
@@ -261,8 +263,13 @@ export abstract class JobHandler {
     }
     \n`;
     const pathPrefix = this.currJob.payload.pathPrefix;
+
+    // Frontend expects docs properties deployed to the root of their bucket to have '/' as their prefix.
+    if (this._currJob.payload.jobType === 'productionDeploy' && pathPrefix === '') {
+      envVars += 'PATH_PREFIX=/\n';
+    }
     // TODO: Do we need the empty string check?
-    if (pathPrefix || pathPrefix === '') {
+    else if (pathPrefix || pathPrefix === '') {
       envVars += `PATH_PREFIX=${pathPrefix}\n`;
     }
     const snootyFrontEndVars = {

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -158,7 +158,7 @@ export class TestDataProvider {
   }
 
   static getEnvVarsWithPathPrefixWithFlags(job: IJob): string {
-    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test`;
+    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\n`;
   }
   static getEnvVarsTestCases(): Array<any> {
     return [

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -219,7 +219,7 @@ describe('ProductionJobHandler Tests', () => {
 
     expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
       `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
-      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\nGATSBY_BASE_URL=test`,
+      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\nGATSBY_BASE_URL=test\n`,
       { encoding: 'utf8', flag: 'w' }
     );
   });

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -207,6 +207,23 @@ describe('ProductionJobHandler Tests', () => {
     });
   });
 
+  test("Production deploy of a job with empty string pathPrefix sets PATH_PREFIX env to '/'", async () => {
+    jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
+    jobHandlerTestHelper.job.payload.repoBranches.prefix = '';
+    jobHandlerTestHelper.job.payload.prefix = '';
+    jobHandlerTestHelper.job.payload.urlSlug = null;
+
+    jobHandlerTestHelper.setupForSuccess();
+    await jobHandlerTestHelper.jobHandler.execute();
+    jobHandlerTestHelper.verifyNextGenSuccess();
+
+    expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
+      `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
+      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\n`,
+      { encoding: 'utf8', flag: 'w' }
+    );
+  });
+
   test('Execute Next Gen Build throws error while executing commands', async () => {
     jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
     jobHandlerTestHelper.setupForSuccess();

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -219,7 +219,7 @@ describe('ProductionJobHandler Tests', () => {
 
     expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
       `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
-      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\n`,
+      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\nGATSBY_BASE_URL=test`,
       { encoding: 'utf8', flag: 'w' }
     );
   });


### PR DESCRIPTION
When the `pathPrefix` is an empty string, and `urlSlug` is `null` or falsy, the frontend should receive `/` as its `PATH_PREFIX` env variable.

### Staging Links

[Atlas](https://docs-atlas-stg.s3.us-east-2.amazonaws.com/index.html)
[Landing](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/index.html)
[Manual](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/manual/) (should have no changes)