### PR TITLE
manifest-prefix-fix: Add conditional to manifestPrefix function

### DIFF
--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -217,7 +217,7 @@ export abstract class JobHandler {
       await this.constructPrefix();
       // if this payload is NOT aliased or if it's the primary alias, we need the index path
       if (!this.currJob.payload.aliased || (this.currJob.payload.aliased && this.currJob.payload.primaryAlias)) {
-        await this.constructManifestIndexPath();
+        this.currJob.payload.manifestPrefix = this.constructManifestPrefix();
       }
 
       this.prepStageSpecificNextGenCommands();
@@ -286,8 +286,12 @@ export abstract class JobHandler {
     return '';
   }
 
-  protected constructManifestIndexPath(): Promise<void> {
-    return Promise.resolve();
+  // For certain unversioned properties, urlSlug is null; use branchName instead
+  protected constructManifestPrefix(): string {
+    if (this.currJob.payload.urlSlug) {
+      return `${this.currJob.payload.project}-${this.currJob.payload.urlSlug}`;
+    }
+    return `${this.currJob.payload.project}-${this.currJob.payload.branchName}`;
   }
 
   protected abstract deploy(): Promise<CommandExecutorResponse>;

--- a/src/job/jobValidator.ts
+++ b/src/job/jobValidator.ts
@@ -67,6 +67,9 @@ export class JobValidator implements IJobValidator {
   }
 
   private _validateInput(job: IJob): void {
+    if (!job.payload.project) {
+      throw new InvalidJobError('Invalid project');
+    }
     if (!['githubPush', 'productionDeploy', 'publishDochub', 'regression'].includes(job.payload.jobType)) {
       throw new InvalidJobError('Invalid JobType');
     }

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -72,15 +72,6 @@ export class ProductionJobHandler extends JobHandler {
     return this.currJob.payload.repoBranches.branches.filter((b) => b['active']).length;
   }
 
-  async constructManifestIndexPath(): Promise<void> {
-    try {
-      this.currJob.payload.manifestPrefix = `${this.currJob.payload.project}-${this.currJob.payload.urlSlug}`;
-    } catch (error) {
-      await this.logger.save(this.currJob._id, error);
-      throw error;
-    }
-  }
-
   getPathPrefix(): string {
     try {
       if (this.currJob.payload.prefix && this.currJob.payload.prefix === '') {


### PR DESCRIPTION
[DOP-2801](https://jira.mongodb.org/browse/DOP-2801). This attempts to solve this issue of incorrect generation of search manifests e.g. `realm-.json `

- Also adds a conditional to the job validator to check that the project string exists. 
- Also moves the function declaration around to be more local to where it is used, and removes Promise / async
Is this appropriate @GuruPKK?