### PR TITLE
DOP-2866: removes continue when active != true

### DIFF
--- a/api/controllers/v1/slack.ts
+++ b/api/controllers/v1/slack.ts
@@ -142,7 +142,6 @@ export const DeployRepo = async (event: any = {}, context: any = {}): Promise<an
     const branchObject = await branchRepository.getRepoBranchAliases(repoName, branchName);
     if (!branchObject?.aliasObject) continue;
 
-    const active = branchObject.aliasObject.active; //bool
     const publishOriginalBranchName = branchObject.aliasObject.publishOriginalBranchName; //bool
     let aliases = branchObject.aliasObject.urlAliases; //array or null
     let urlSlug = branchObject.aliasObject.urlSlug; //string or null, string must match value in urlAliases or gitBranchName
@@ -150,10 +149,6 @@ export const DeployRepo = async (event: any = {}, context: any = {}): Promise<an
     aliases = aliases?.filter((a) => a);
     if (!urlSlug || !!urlSlug.trim()) {
       urlSlug = branchName;
-    }
-
-    if (!active) {
-      continue;
     }
 
     //Generic payload, will be conditionaly modified appropriately


### PR DESCRIPTION
Inactive branches may, regrettably, still need to be deployed. Inactive branches that build on Snooty need to be deployed
via the Autobuilder. This continue causes attempts to deploy active: false branches to silently fail to push to the queue, which makes EOL-ing 'legacy' docs impossible.

(This replaces the PR from my fork, which can't github action due to its being a fork.)