### PR TITLE
DOP-2866: permit building to '/' if urlSlug == null and publishOriginalBranchName == false

### DIFF
--- a/api/controllers/v1/slack.ts
+++ b/api/controllers/v1/slack.ts
@@ -189,7 +189,8 @@ export const DeployRepo = async (event: any = {}, context: any = {}): Promise<an
         deployHelper(deployable, newPayload, jobTitle, jobUserName, jobUserEmail);
         jobCount += 1;
       }
-      if (non_versioned) {
+      // handle non-versioned repos AND repos where only 1 version is active
+      if (non_versioned || (!publishOriginalBranchName && urlSlug === null)) {
         newPayload.urlSlug = '';
         deployHelper(deployable, newPayload, jobTitle, jobUserName, jobUserEmail);
         jobCount += 1;


### PR DESCRIPTION
Why would you want to do this? You're Charts and you've only got 1 actual version, but also a legacy version that you want to build. You actual version should stay at www.mongodb.com/docs/charts/ not at www.mongod.com/docs/charts/master, while 19.12 should build to www.mongodb.com/docs/charts/19.12/.