### PR TITLE
DOP-2902: Perform wildcard invalidations when invalidating more than 250 objects

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - "master"
       - "integration"
-      - "DOP-2902"
 concurrency:
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - "master"
       - "integration"
+      - "DOP-2902"
 concurrency:
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -100,13 +100,8 @@ export class ProductionJobHandler extends JobHandler {
       const updatedURLsArray = stdoutJSON.urls;
       // purgeCache purges the now stale content and requests the URLs to warm the cache for our users
       await this.logger.save(this.currJob._id, JSON.stringify(updatedURLsArray));
-      console.log('this.currJob.payload.pathPrefix : ' + this.currJob.payload.pathPrefix);
-      console.log('this.currJob.payload.pathPrefix as string : ' + (this.currJob.payload.pathPrefix as string));
-      const id = await this._cdnConnector.purge(
-        this.currJob._id,
-        updatedURLsArray,
-        this.currJob.payload.pathPrefix as string
-      );
+      console.log('this.currJob.payload.prefix : ' + this.currJob.payload.prefix);
+      const id = await this._cdnConnector.purge(this.currJob._id, updatedURLsArray, this.currJob.payload.prefix);
       await this.jobRepository.insertPurgedUrls(this.currJob._id, updatedURLsArray);
       if (id) {
         await this.jobRepository.insertInvalidationRequestStatusUrl(

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -100,7 +100,7 @@ export class ProductionJobHandler extends JobHandler {
       const updatedURLsArray = stdoutJSON.urls;
       // purgeCache purges the now stale content and requests the URLs to warm the cache for our users
       await this.logger.save(this.currJob._id, JSON.stringify(updatedURLsArray));
-      const id = await this._cdnConnector.purge(this.currJob._id, updatedURLsArray);
+      const id = await this._cdnConnector.purge(this.currJob._id, updatedURLsArray, this.currJob.payload.pathPrefix);
       await this.jobRepository.insertPurgedUrls(this.currJob._id, updatedURLsArray);
       if (id) {
         await this.jobRepository.insertInvalidationRequestStatusUrl(

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -100,7 +100,13 @@ export class ProductionJobHandler extends JobHandler {
       const updatedURLsArray = stdoutJSON.urls;
       // purgeCache purges the now stale content and requests the URLs to warm the cache for our users
       await this.logger.save(this.currJob._id, JSON.stringify(updatedURLsArray));
-      const id = await this._cdnConnector.purge(this.currJob._id, updatedURLsArray, this.currJob.payload.pathPrefix);
+      console.log('this.currJob.payload.pathPrefix : ' + this.currJob.payload.pathPrefix);
+      console.log('this.currJob.payload.pathPrefix as string : ' + (this.currJob.payload.pathPrefix as string));
+      const id = await this._cdnConnector.purge(
+        this.currJob._id,
+        updatedURLsArray,
+        this.currJob.payload.pathPrefix as string
+      );
       await this.jobRepository.insertPurgedUrls(this.currJob._id, updatedURLsArray);
       if (id) {
         await this.jobRepository.insertInvalidationRequestStatusUrl(

--- a/src/job/productionJobHandler.ts
+++ b/src/job/productionJobHandler.ts
@@ -100,7 +100,7 @@ export class ProductionJobHandler extends JobHandler {
       const updatedURLsArray = stdoutJSON.urls;
       // purgeCache purges the now stale content and requests the URLs to warm the cache for our users
       await this.logger.save(this.currJob._id, JSON.stringify(updatedURLsArray));
-      console.log('this.currJob.payload.prefix : ' + this.currJob.payload.prefix);
+      console.log('current job prefix to be used for wildcard url invalidation: ' + this.currJob.payload.prefix);
       const id = await this._cdnConnector.purge(this.currJob._id, updatedURLsArray, this.currJob.payload.prefix);
       await this.jobRepository.insertPurgedUrls(this.currJob._id, updatedURLsArray);
       if (id) {

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -141,7 +141,7 @@ export class K8SCDNConnector implements ICDNConnector {
     });
 
     // perform wildcard invalidations when invalidating >= 250 objects
-    if (urls.length >= 1) {
+    if (urls.length >= 250) {
       const wildcardPatternURL = '/' + prefix + '/*';
       urls = [wildcardPatternURL];
     }

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -7,7 +7,7 @@ import { ISSOConnector } from './sso';
 export const axiosApi = axios.create();
 
 export interface ICDNConnector {
-  purge(jobId: string, urls: Array<string>, pathPrefix: string | null | undefined): Promise<string | null>;
+  purge(jobId: string, urls: Array<string>, pathPrefix: string): Promise<string | null>;
   purgeAll(creds: CDNCreds): Promise<any>;
   warm(jobId: string, url: string): Promise<any>;
   upsertEdgeDictionaryItem(keyValue: any, id: string, creds: CDNCreds): Promise<void>;
@@ -40,7 +40,7 @@ export class FastlyConnector implements ICDNConnector {
     return await axiosApi.get(url);
   }
 
-  async purge(jobId: string, urls: Array<string>, pathPrefix: string | null | undefined): Promise<string> {
+  async purge(jobId: string, urls: Array<string>, pathPrefix: string): Promise<string> {
     const purgeUrlPromises = urls.map((url) => this.purgeURL(url));
     await Promise.all(
       purgeUrlPromises.map((p) =>
@@ -130,7 +130,7 @@ export class K8SCDNConnector implements ICDNConnector {
     };
   }
 
-  async purge(jobId: string, urls: string[], pathPrefix: string | null | undefined): Promise<string | null> {
+  async purge(jobId: string, urls: string[], pathPrefix: string): Promise<string | null> {
     console.log('K8SCDNConnector purge');
     const url = this._config.get<string>('cdnInvalidatorServiceURL');
     console.log(url);
@@ -140,8 +140,10 @@ export class K8SCDNConnector implements ICDNConnector {
       return `/${item}`;
     });
 
+    console.log('pathPrefix: ' + pathPrefix);
+    console.log('urls: ' + urls);
     // perform wildcard invalidations when invalidating >= 250 objects
-    if (urls.length >= 250) {
+    if (urls.length >= 1) {
       const wildcardPatternURL = '/' + pathPrefix + '/*';
       urls = [wildcardPatternURL];
     }

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -140,7 +140,7 @@ export class K8SCDNConnector implements ICDNConnector {
       return `/${item}`;
     });
 
-    if (urls.length >= 1) {
+    if (urls.length >= 250) {
       const wildcardPatternURL = '/' + pathPrefix + '/*';
       urls = [wildcardPatternURL];
       try {

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -140,12 +140,13 @@ export class K8SCDNConnector implements ICDNConnector {
       return `/${item}`;
     });
 
-    if (urls.length >= 250) {
+    if (urls.length >= 1) {
       const wildcardPatternURL = '/' + pathPrefix + '/*';
+      urls = [wildcardPatternURL];
       try {
-        const res = await axios.post(url, { paths: [wildcardPatternURL] }, { headers: headers });
+        const res = await axios.post(url, { paths: urls }, { headers: headers });
         console.log(res);
-        this._logger.info(jobId, `Total urls purged 1`);
+        this._logger.info(jobId, `Total urls purged ${urls.length}`);
         return res?.data?.id;
       } catch (err) {
         this._logger.error(jobId, JSON.stringify(err?.response?.data));

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -7,7 +7,7 @@ import { ISSOConnector } from './sso';
 export const axiosApi = axios.create();
 
 export interface ICDNConnector {
-  purge(jobId: string, urls: Array<string>, pathPrefix: string): Promise<string | null>;
+  purge(jobId: string, urls: Array<string>, prefix: string): Promise<string | null>;
   purgeAll(creds: CDNCreds): Promise<any>;
   warm(jobId: string, url: string): Promise<any>;
   upsertEdgeDictionaryItem(keyValue: any, id: string, creds: CDNCreds): Promise<void>;
@@ -40,7 +40,7 @@ export class FastlyConnector implements ICDNConnector {
     return await axiosApi.get(url);
   }
 
-  async purge(jobId: string, urls: Array<string>, pathPrefix: string): Promise<string> {
+  async purge(jobId: string, urls: Array<string>, prefix: string): Promise<string> {
     const purgeUrlPromises = urls.map((url) => this.purgeURL(url));
     await Promise.all(
       purgeUrlPromises.map((p) =>
@@ -130,7 +130,7 @@ export class K8SCDNConnector implements ICDNConnector {
     };
   }
 
-  async purge(jobId: string, urls: string[], pathPrefix: string): Promise<string | null> {
+  async purge(jobId: string, urls: string[], prefix: string): Promise<string | null> {
     console.log('K8SCDNConnector purge');
     const url = this._config.get<string>('cdnInvalidatorServiceURL');
     console.log(url);
@@ -140,11 +140,9 @@ export class K8SCDNConnector implements ICDNConnector {
       return `/${item}`;
     });
 
-    console.log('pathPrefix: ' + pathPrefix);
-    console.log('urls: ' + urls);
     // perform wildcard invalidations when invalidating >= 250 objects
     if (urls.length >= 1) {
-      const wildcardPatternURL = '/' + pathPrefix + '/*';
+      const wildcardPatternURL = '/' + prefix + '/*';
       urls = [wildcardPatternURL];
     }
 

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -140,18 +140,10 @@ export class K8SCDNConnector implements ICDNConnector {
       return `/${item}`;
     });
 
+    // perform wildcard invalidations when invalidating >= 250 objects
     if (urls.length >= 250) {
       const wildcardPatternURL = '/' + pathPrefix + '/*';
       urls = [wildcardPatternURL];
-      try {
-        const res = await axios.post(url, { paths: urls }, { headers: headers });
-        console.log(res);
-        this._logger.info(jobId, `Total urls purged ${urls.length}`);
-        return res?.data?.id;
-      } catch (err) {
-        this._logger.error(jobId, JSON.stringify(err?.response?.data));
-      }
-      return null;
     }
 
     try {

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -400,7 +400,11 @@ describe('ProductionJobHandler Tests', () => {
     expect(jobHandlerTestHelper.job.deployCommands).toEqual(
       TestDataProvider.getCommonDeployCommands(jobHandlerTestHelper.job)
     );
-    expect(jobHandlerTestHelper.cdnConnector.purge).toBeCalledWith(jobHandlerTestHelper.job._id, purgedUrls);
+    expect(jobHandlerTestHelper.cdnConnector.purge).toBeCalledWith(
+      jobHandlerTestHelper.job._id,
+      purgedUrls,
+      jobHandlerTestHelper.job.payload.pathPrefix
+    );
     expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toBeCalledWith(jobHandlerTestHelper.job._id, purgedUrls);
     expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);
   });

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -403,7 +403,7 @@ describe('ProductionJobHandler Tests', () => {
     expect(jobHandlerTestHelper.cdnConnector.purge).toBeCalledWith(
       jobHandlerTestHelper.job._id,
       purgedUrls,
-      jobHandlerTestHelper.job.payload.pathPrefix
+      jobHandlerTestHelper.job.payload.prefix
     );
     expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toBeCalledWith(jobHandlerTestHelper.job._id, purgedUrls);
     expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);

--- a/tests/unit/services/K8SCDNConnector.test.ts
+++ b/tests/unit/services/K8SCDNConnector.test.ts
@@ -1,0 +1,59 @@
+import { K8SCDNConnector, axiosApi } from '../../../src/services/cdn';
+import { mockDeep } from 'jest-mock-extended';
+import MockAdapter from 'axios-mock-adapter';
+import { IConfig } from 'config';
+import { ILogger } from './../../../src/services/logger';
+import { ISSMConnector } from './../../../src/services/ssm';
+import { ISSOConnector } from './../../../src/services/sso';
+
+describe('K8SCDNConnector Tests', () => {
+  let k8SCDNConnector: K8SCDNConnector;
+  let mock;
+  let logger;
+  let ssmConnecotr;
+  let config;
+  let ssoConnector;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axiosApi);
+    logger = mockDeep<ILogger>();
+    ssmConnecotr = mockDeep<ISSMConnector>();
+    config = mockDeep<IConfig>();
+    ssoConnector = mockDeep<ISSOConnector>();
+
+    k8SCDNConnector = new K8SCDNConnector(config, logger, ssmConnecotr, ssoConnector);
+  });
+  afterEach(() => {
+    mock.reset();
+  });
+
+  test('Construct K8SCDNConnector', () => {
+    expect(new K8SCDNConnector(config, logger, ssmConnecotr, ssoConnector)).toBeDefined();
+  });
+
+  describe('K8SCDNConnector purge tests', () => {
+    beforeEach(() => {
+      jest.setTimeout(30000);
+    });
+    test('K8SCDNConnector purge succeeds', async () => {
+      const k8SCDNConnector = new K8SCDNConnector(
+        mockDeep<IConfig>(),
+        mockDeep<ILogger>(),
+        mockDeep<ISSMConnector>(),
+        mockDeep<ISSOConnector>()
+      );
+      await k8SCDNConnector.purge(
+        'test_job_id',
+        [
+          '/docs/compass/upcoming/29107295-e47455e7b3c92fba2a11.js.map',
+          '/docs/compass/upcoming/import-pipeline-from-text/index.html',
+        ],
+        'docs/compass'
+      );
+    });
+    // afterAll(async () => {
+    //   await new Promise(resolve => setTimeout(() => resolve(), 5000)); // avoid jest open handle error
+    // });
+    // expect(mock.history.put.length).toBe(1);
+  });
+});

--- a/tests/unit/services/K8SCDNConnector.test.ts
+++ b/tests/unit/services/K8SCDNConnector.test.ts
@@ -1,7 +1,7 @@
-import { K8SCDNConnector } from '../../../src/services/cdn';
 import axios from 'axios';
 import { mockDeep } from 'jest-mock-extended';
 import { IConfig } from 'config';
+import { K8SCDNConnector } from '../../../src/services/cdn';
 import { ILogger } from './../../../src/services/logger';
 import { ISSMConnector } from './../../../src/services/ssm';
 import { ISSOConnector } from './../../../src/services/sso';


### PR DESCRIPTION
[DOP-2902](https://jira.mongodb.org/browse/DOP-2902)

This ticket allows for a single wildcard invalidation in the CloudFront CDN instead of multiple individual objects being invalidated, which is an expensive operation. 

Notes: 
Before merge, the temporary workaround for the staging pipeline and the threshold for URL wildcard purging (which is currently set to 1 for testing purposes, should be 250) will be changed. Extraneous console.log()s will also be removed, which were added for greater visibility in the logs.  

[Invalidation Status for Atlas](https://cdnvalidator.devops.staging.corp.mongodb.com/api/v1beta1/distributions/mongodbcom-staging-docs/invalidations/I2HFI80AX9C73S)
[Invalidation Status for Docs](https://cdnvalidator.devops.staging.corp.mongodb.com/api/v1beta1/distributions/mongodbcom-staging-docs/invalidations/IR806NQ7UPO0U)