### PR TITLE
DOP-2711: add makefile & published branches for cluster-sync

### DIFF
--- a/makefiles/Makefile.docs-cluster-to-cluster-sync
+++ b/makefiles/Makefile.docs-cluster-to-cluster-sync
@@ -1,0 +1,21 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+ifeq ($(STAGING_USERNAME),)
+	USER=$(shell whoami)
+else
+	USER=$(STAGING_USERNAME)
+endif
+
+PROJECT=cluster-sync
+MUT_PREFIX ?= $(PROJECT)
+
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-cluster-to-cluster-sync.yaml > ${REPO_DIR}/published-branches.yaml

--- a/publishedbranches/docs-cluser-to-cluster-sync.yaml
+++ b/publishedbranches/docs-cluser-to-cluster-sync.yaml
@@ -1,0 +1,16 @@
+prefix: 'cluster-sync'
+version:
+  published:
+    - 'master'
+  active:
+    - 'master'
+  stable: 'master'
+  upcoming: master
+git:
+  branches:
+    manual: 'master'
+    published:
+      - 'master'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...


### PR DESCRIPTION
Also adds a dodgy little publishedbranches since there's a build step that looks for it even though it's unnecessary.