### PR TITLE
[DOP-2946] stabilize staging pipeline

### DIFF
--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -1,9 +1,12 @@
 on:
   push:
-    branches-ignore:
-      - "integration"
+    branches:
       - "master"
-      - "meta"
+      - "integration"
+  pull_request:
+    branches:
+      - master
+      - integration
 concurrency:
   group: environment-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -1,13 +1,8 @@
 on:
   push:
     branches:
-      - "integration"
       - "master"
-      - "DOP-2508"
-  pull_request:
-    branches:
-      - master
-      - integration
+      - "integration"
 concurrency:
   group: environment-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR updates the triggers for the dev and staging pipeline so that we don't deploy into staging via pull request.
We'll still have to revisit the pipeline, but this should make staging reflect the main branch.

If we need to deploy into staging of a feature branch, then the pipeline trigger can be manually updated for that branch.