### PR TITLE
DOP-N/A: Only enqueue a manifest for primaryAliases

### DIFF
--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -446,6 +446,11 @@ export abstract class JobHandler {
     if (doNotSearchProperties.includes(this.currJob.payload.repoName)) {
       return false;
     }
+    // Ensures that we only build a manifest for aliased properties if the job
+    // is for a primary alias
+    if (this.currJob.payload.aliased && !this.currJob.payload.primaryAlias) {
+      return false;
+    }
     // Edit this if you want to generate search manifests for dev environments, too
     if (this.currJob.payload.jobType !== 'productionDeploy') {
       return false;


### PR DESCRIPTION
Adds a boolean to check if the property being deployed is aliased, and whether it is the primary alias.

Only enqueues a manifest generation on primary alias jobs for aliased properties.