### PR TITLE
DOP-2978: Fix manifest prefix for cloud-docs

### DIFF
--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -305,7 +305,7 @@ export abstract class JobHandler {
     // name correction AND snooty frontend dropdown de-hardcoding
     const substitute = {
       cloudgov: 'AtlasGov',
-      cloud: 'atlas',
+      'cloud-docs': 'atlas',
       docs: 'manual',
     };
     const projectName = substitute[this.currJob.payload.project] ?? this.currJob.payload.project;

--- a/tests/unit/job/manifestJobHandler.test.ts
+++ b/tests/unit/job/manifestJobHandler.test.ts
@@ -87,7 +87,7 @@ describe('ManifestJobHandler Tests', () => {
       manifestPrefix: `AtlasGov-testSlug`,
     },
     {
-      project: 'cloud',
+      project: 'cloud-docs',
       urlSlug: 'testSlug',
       branchName: '',
       manifestPrefix: `atlas-testSlug`,


### PR DESCRIPTION
Ran a `test-deploy` and `atlas-master.json` exists!