### PR TITLE
Update custom-environment-variables.json

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -56,6 +56,5 @@
   "cdnClientID": "CDN_CLIENT_ID",
   "cdnClientSecret": "CDN_CLIENT_SECRET",
   "cdnInvalidatorServiceURL": "CDN_INVALIDATOR_SERVICE_URL",
-  "searchIndexBucket": "SEARCH_INDEX_BUCKET",
-  "searchIndexFolder": "SEARCH_INDEX_FOLDER"
+  "searchIndexBucket": "SEARCH_INDEX_BUCKET"
 }


### PR DESCRIPTION
Stops us from loading search folder value from container ENV values and instead loads from default config.


