### PR TITLE
DOP-3054: Add redirects for docs/master to docs/upcoming

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -5,6 +5,13 @@ Resources:
       BucketName: ${self:custom.bucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          RoutingRules:
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/docs/master
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/docs/upcoming
   DocAtlasBucket:
     Type: "AWS::S3::Bucket"
     Properties:

--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -156,6 +156,19 @@ custom:
     prd: "prd"
     dotcomstg: "preprd"
     dotcomprd: "prd"
+  site:
+    host:
+      dev: "docs-dev.mongodb.com"
+      stg: "mongodbcom-cdn.website.staging.corp.mongodb.com"
+      dotcomstg: "mongodbcom-cdn.website.staging.corp.mongodb.com"
+      prd: "www.mongodb.com"
+      dotcomprd: "www.mongodb.com"
+    prefix:
+      dev: "docs"
+      stg: "docs-qa"
+      dotcomstg: "docs-qa"
+      prd: "docs"
+      dotcomprd: "docs"
 
 resources:
   - ${file(./buckets.yml)}


### PR DESCRIPTION
[DOP-3054](https://jira.mongodb.org/browse/DOP-3054)

This PR redirects any URLs following the format of `docs/master/*` to `docs/upcoming/*`.