### PR TITLE
DOP-2861: Add GitHub Workflow for CI (Linting, Formatting & Tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - name: Lint
+      run: npm run lint && npm run format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: '14.x'
     - name: Lint
       run: npm run lint && npm run format
+    - name: Test
+      run: npm test
+      continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '14.x'
+    - name: Install dependencies
+      run: npm install --dev
     - name: Lint
       run: npm run lint && npm run format
     - name: Test


### PR DESCRIPTION
### Ticket

[DOP-2861](https://jira.mongodb.org/browse/DOP-2861)

### Description

Adds a basic CI infrastructure to all autobuilder PRs via GitHub Actions. The job currently runs eslint for linting, Prettier for formatting, and jest for unit testing.

**Note**:  11 of the 153 tests currently fail. We will address the failing tests in another ticket. For now, I've included the `continue-on-error` flag to ensure the overall run is treated as a success regardless of test failures. Once we've fixed the tests, we should remove the line from `test.yml`

Follow-up work is being tracked in [DOP-3080](https://jira.mongodb.org/browse/DOP-3080)