### PR TITLE
DOP-3071: Update docs-404 Makefile to upload built assets to multiple environment-specific S3 buckets

### DIFF
--- a/makefiles/Makefile.docs-404
+++ b/makefiles/Makefile.docs-404
@@ -16,7 +16,7 @@ else ifeq ($(SNOOTY_ENV), dotcomprd)
 	EXECUTE_DEPLOY=true
 endif
 
-DEPLOY_JOBS=job-$(BUCKET) job-docs-atlas-$(SNOOTY_ENV) job-docs-cloudmanager-$(SNOOTY_ENV) job-docs-opsmanager-$(SNOOTY_ENV) job-docs-java-$(SNOOTY_ENV) job-docs-go-$(SNOOTY_ENV) job-docs-node-$(SNOOTY_ENV)
+DEPLOY_JOBS=job-$(BUCKET) job-docs-atlas-$(SNOOTY_ENV) job-docs-java-$(SNOOTY_ENV) job-docs-go-$(SNOOTY_ENV) job-docs-node-$(SNOOTY_ENV)
 
 .PHONY: next-gen-html next-gen-stage next-gen-deploy $(DEPLOY_JOBS)
 

--- a/makefiles/Makefile.docs-404
+++ b/makefiles/Makefile.docs-404
@@ -1,6 +1,6 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 USER=$(shell whoami)
-SNOOTY_ENV = $(shell printenv SNOOTY_ENV
+SNOOTY_ENV = $(shell printenv SNOOTY_ENV)
 BUCKET = $(shell printenv BUCKET)
 
 REPO_DIR=$(shell pwd)

--- a/makefiles/Makefile.docs-404
+++ b/makefiles/Makefile.docs-404
@@ -1,16 +1,8 @@
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-
-SNOOTY_ENV = $(shell printenv SNOOTY_ENV)
-
-
+USER=$(shell whoami)
+SNOOTY_ENV = $(shell printenv SNOOTY_ENV
 BUCKET = $(shell printenv BUCKET)
-URL = $(shell printenv URL)
 
-ifeq ($(STAGING_USERNAME),)
-	USER=$(shell whoami)
-else
-	USER=$(STAGING_USERNAME)
-endif
 REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
@@ -18,14 +10,13 @@ PROJECT=docs-404
 MUT_PREFIX=404
 CUSTOM_NEXT_GEN_DEPLOY=true
 
-
-ifeq ($(SNOOTY_ENV), production) 
-	DEPLOY_JOBS=docs-mongodb-org-prd
-else ifeq ($(SNOOTY_ENV), staging)
-	DEPLOY_JOBS=docs-mongodb-org-stg
-else ifeq ($(SNOOTY_ENV), regression)
-	DEPLOY_JOBS=docs-mongodb-org-intgr
+ifeq ($(SNOOTY_ENV), dotcomstg)
+	EXECUTE_DEPLOY=true
+else ifeq ($(SNOOTY_ENV), dotcomprd)
+	EXECUTE_DEPLOY=true
 endif
+
+DEPLOY_JOBS=job-$(BUCKET) job-docs-atlas-$(SNOOTY_ENV) job-docs-cloudmanager-$(SNOOTY_ENV) job-docs-opsmanager-$(SNOOTY_ENV) job-docs-java-$(SNOOTY_ENV) job-docs-go-$(SNOOTY_ENV) job-docs-node-$(SNOOTY_ENV)
 
 .PHONY: next-gen-html next-gen-stage next-gen-deploy $(DEPLOY_JOBS)
 
@@ -37,5 +28,7 @@ get-build-dependencies:
 
 next-gen-deploy: $(DEPLOY_JOBS)
 
+ifdef EXECUTE_DEPLOY
 $(DEPLOY_JOBS): job-%:
 	yes | mut-publish public $* --prefix="${MUT_PREFIX}" --deploy --all-subdirectories ${ARGS}
+endif


### PR DESCRIPTION
### Ticket

[DOP-3071](https://jira.mongodb.org/browse/DOP-3071?src=confmacro)

### Notes

To add custom 404 pages back to our site post subdomain consolidation, we need to upload the built version of the `docs-404` content repo to each of the 7 buckets that hosts docs content (`docs-java-{env}`, `docs-mongodb-org-{env}`, etc). Since we only need to display a custom 404 page in production and pre-production environments, the Makefile only uploads the built files using `mut` if `SNOOTY_ENV` is equal to `dotcomprd` or `dotcomstg`.

### Testing Story

After this PR has been merged, we will need to run a `/test-deploy` in Slack on `docs-404` to see if the files get uploaded successfully.

- [ ] Before running `/test-deploy`, we'll need to add `docs-404` to the `pool.repo_branches` collection in order to satisfy the autobuilder. Here's my suggested document to insert:

```
{
  "repoName": "docs-404",
  "branches": [
    {
      "publishOriginalBranchName": false,
      "active": true,
      "gitBranchName": "master",
      "isStableBranch": false,
      "urlAliases": null,
      "urlSlug": null,
      "versionSelectorLabel": "master",
      "buildsWithSnooty": true
    }
  ],
  "bucket": {
    "dotcomstg": "docs-mongodb-org-dotcomstg",
    "dotcomprd": "docs-mongodb-org-dotcomprd"
  },
  "url": {
    "dotcomprd": "http://mongodb.com/",
    "dotcomstg": "https://mongodbcom-cdn.website.staging.corp.mongodb.com/"
    
  },
  "prefix": {    
    "dotcomstg": “docs/404”,
    "dotcomprd": "docs/404”
  },
  "project": “docs-404”
}
```

In the Makefile, you'll see that we leverage the `BUCKET` environment variable, which will be either `docs-mongodb-org-dotcomstg` or `docs-mongodb-org-dotcomprd` since the autobuilder sources the value from `repo_branches`.