### PR TITLE
DOP-2965: Use snooty manifests for bi-connector

### DIFF
--- a/makefiles/Makefile.docs-bi-connector
+++ b/makefiles/Makefile.docs-bi-connector
@@ -25,15 +25,15 @@ include ~/shared.mk
 
 next-gen-html: get-build-dependencies
 	# snooty parse and then build-front-end
-	@if [ -n "${PATCH_ID}" ]; then \
-		echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG}; \
+	if [ -n "${PATCH_ID}" ]; then \
+		snooty build "${REPO_DIR}" --output "${REPO_DIR}/bundle.zip" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" ${RSTSPEC_FLAG}; \
+		snooty build "${REPO_DIR}" --output "${REPO_DIR}/bundle.zip" ${RSTSPEC_FLAG}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
@@ -48,7 +48,7 @@ next-gen-html: get-build-dependencies
 		echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production && \
 		echo "PATCH_ID=${PATCH_ID}" >> .env.production; \
 	fi && \
-	npm run build; \
+	GATSBY_MANIFEST_PATH="${REPO_DIR}/bundle.zip" npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 
 next-gen-stage: ## Host online for review


### PR DESCRIPTION
Switch to using snooty manifests rather than Atlas for document exchange on bi-connector.

```
make -f ~/work/docs-worker-pool/makefiles/Makefile.docs-bi-connector next-gen-html
```
performs a complete build