### PR TITLE
DOP-3071: Update CloudFormation template to specify custom S3 error document

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -5,6 +5,7 @@ Resources:
       BucketName: ${self:custom.bucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
           RoutingRules:
             - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/docs/master
@@ -18,12 +19,14 @@ Resources:
       BucketName: ${self:custom.atlasBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
   CloudManagerBucket:
     Type: "AWS::S3::Bucket"
     Properties:
       BucketName: ${self:custom.cloudManagerBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
   OpsManagerBucket:
     Type: "AWS::S3::Bucket"
@@ -31,6 +34,7 @@ Resources:
       BucketName: ${self:custom.opsManagerBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
   JavaBucket:
     Type: "AWS::S3::Bucket"
@@ -38,6 +42,7 @@ Resources:
       BucketName: ${self:custom.javaBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
   GoBucket:
     Type: "AWS::S3::Bucket"
@@ -45,6 +50,7 @@ Resources:
       BucketName: ${self:custom.goBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
   NodeBucket:
     Type: "AWS::S3::Bucket"
@@ -52,6 +58,7 @@ Resources:
       BucketName: ${self:custom.nodeBucketName}
       WebsiteConfiguration:
           IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
   DocsBucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -169,6 +169,9 @@ custom:
       dotcomstg: "docs-qa"
       prd: "docs"
       dotcomprd: "docs"
+    errorDoc:
+      dotcomstg: "docs-qa/404/index.html"
+      dotcomprd: "docs/404/index.html"
 
 resources:
   - ${file(./buckets.yml)}


### PR DESCRIPTION
### Ticket

[DOP-3071](https://jira.mongodb.org/browse/DOP-3071)

### Notes

A follow-up to #674. Successfully tested the Makefile in preprod `dotcomstg` environment. We now need to update our CloudFormation stack to ensure the 404 page is served in both `dotcomstg` and `dotcomprd` environments.

Goal is to only set the `ErrorDocument` property in `dotcomstg` and `dotcomprd`. Outside of those environments, we will continue to serve the default S3 error page.