### PR TITLE
update master -> upcoming redirect

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -7,11 +7,11 @@ Resources:
           IndexDocument: index.html
           RoutingRules:
             - RoutingRuleCondition:
-                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/docs/master
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/master
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/docs/upcoming
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/upcoming
   DocAtlasBucket:
     Type: "AWS::S3::Bucket"
     Properties:


### PR DESCRIPTION
## Related Links
- https://github.com/mongodb/docs-worker-pool/pull/667
- https://github.com/mongodb/docs-worker-pool/pull/679

## Description
This PR removes the redundant prefix in the redirect rule we have on s3. For example the condition `docs-qa/docs/master` becomes just `docs-qa/master`.

