### PR TITLE
DOP-2866: fix semi-versioned repo logic harder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,3 @@ jobs:
       run: npm run lint && npm run format
     - name: Test
       run: npm test
-      continue-on-error: true

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -19,12 +19,6 @@
   "taskDefinitionFamily": "TASK_DEFINITION_FAMILY",
   "jobsQueueUrl": "JOBS_QUEUE_URL",
   "jobUpdatesQueueUrl": "JOB_UPDATES_QUEUE_URL",
-  "cdn_creds": {
-    "dochub": {
-      "id": "FASTLY_DOCHUB_SERVICE_ID",
-      "token": "FASTLY_DOCHUB_TOKEN"
-    }
-  },
   "cdnClientID": "CDN_CLIENT_ID",
   "cdnClientSecret": "CDN_CLIENT_SECRET",
   "cdnInvalidatorServiceURL": "CDN_INVALIDATOR_SERVICE_URL",

--- a/api/config/default.json
+++ b/api/config/default.json
@@ -44,12 +44,6 @@
       "parallelStgName": "dotcomprd"
     }
   },
-  "cdn_creds": {
-    "dochub": {
-      "id": "FASTLY_DOCHUB_SERVICE_ID",
-      "token": "FASTLY_DOCHUB_TOKEN"
-    }
-  },
   "prodDeploy": {
     "restrictedProdDeploy": false,
     "entitledSlackUsers": [

--- a/api/controllers/v1/slack.ts
+++ b/api/controllers/v1/slack.ts
@@ -144,7 +144,8 @@ export const getDeployableJobs = async (values, entitlement, branchRepository: B
     );
 
     if (!aliases || aliases.length === 0) {
-      if (non_versioned) {
+        // handle non-versioned repos AND repos where only 1 version is active where there are no aliases
+      if (non_versioned || (!publishOriginalBranchName && urlSlug === null))) {
         newPayload.urlSlug = '';
       }
       deployHelper(deployable, newPayload, jobTitle, jobUserName, jobUserEmail);

--- a/api/controllers/v1/slack.ts
+++ b/api/controllers/v1/slack.ts
@@ -144,8 +144,8 @@ export const getDeployableJobs = async (values, entitlement, branchRepository: B
     );
 
     if (!aliases || aliases.length === 0) {
-        // handle non-versioned repos AND repos where only 1 version is active where there are no aliases
-      if (non_versioned || (!publishOriginalBranchName && urlSlug === null))) {
+      // handle non-versioned repos AND repos where only 1 version is active where there are no aliases
+      if (non_versioned || (!publishOriginalBranchName && urlSlug === null)) {
         newPayload.urlSlug = '';
       }
       deployHelper(deployable, newPayload, jobTitle, jobUserName, jobUserEmail);

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -27,32 +27,6 @@
   "jobId": "jobId",
   "jobsQueueUrl": "JOBS_QUEUE_URL",
   "jobUpdatesQueueUrl": "JOB_UPDATES_QUEUE_URL",
-  "cdn_creds": {
-    "cloudgov-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs-osb": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "devhub-content": {
-      "id": "FASTLY_DEVHUB_SERVICE_ID",
-      "token": "FASTLY_DEVHUB_TOKEN"
-    },
-    "dochub": {
-      "id": "FASTLY_DOCHUB_SERVICE_ID",
-      "token": "FASTLY_DOCHUB_TOKEN"
-    },
-    "main": {
-      "id": "FASTLY_MAIN_SERVICE_ID",
-      "token": "FASTLY_MAIN_TOKEN"
-    }
-  },
   "cdnClientID": "CDN_CLIENT_ID",
   "cdnClientSecret": "CDN_CLIENT_SECRET",
   "cdnInvalidatorServiceURL": "CDN_INVALIDATOR_SERVICE_URL",

--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,6 @@
   "PORT": 3000,
   "MAX_STDOUT_BUFFER_SIZE": 16000000,
   "GATSBY_PARSER_USER": "docsworker-xlarge",
-  "shouldPurgeAll": false,
   "fastlyOpsManagerToken": "FASTLY_OPS_MANAGER_TOKEN",
   "fastlyOpsManagerServiceId": "FASTLY_OPS_MANAGER_SERVICE_ID",
   "fastlyCloudManagerToken": "FASTLY_CLOUD_MANAGER_TOKEN",
@@ -51,32 +50,6 @@
     "stg": "https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches",
     "dotcomstg": "https://raw.githubusercontent.com/mongodb/docs-worker-pool/DOP-2747-meta/publishedbranches",
     "dotcomprd": "https://raw.githubusercontent.com/mongodb/docs-worker-pool/DOP-2747-meta/publishedbranches"
-  },
-  "cdn_creds": {
-    "cloudgov-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs-osb": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "token": "FASTLY_ATLAS_TOKEN"
-    },
-    "devhub-content": {
-      "id": "FASTLY_DEVHUB_SERVICE_ID",
-      "token": "FASTLY_DEVHUB_TOKEN"
-    },
-    "publishDochub": {
-      "id": "FASTLY_DOCHUB_SERVICE_ID",
-      "token": "FASTLY_DOCHUB_TOKEN"
-    },
-    "main": {
-      "id": "FASTLY_MAIN_SERVICE_ID",
-      "token": "FASTLY_MAIN_TOKEN"
-    }
   },
   "repo_dir": "repos",
   "cdnInvalidationOauthScope": "mongodbcom-docs",

--- a/config/test.json
+++ b/config/test.json
@@ -22,38 +22,10 @@
   "LOG_PADDING": 15,
   "PORT": 3000,
   "GATSBY_PARSER_USER": "docsworker-xlarge",
-  "shouldPurgeAll": false,
   "fastlyOpsManagerToken": "FASTLY_OPS_MANAGER_TOKEN",
   "fastlyOpsManagerServiceId": "FASTLY_OPS_MANAGER_SERVICE_ID",
   "fastlyCloudManagerToken": "FASTLY_CLOUD_MANAGER_TOKEN",
   "fastlyCloudManagerServiceId": "FASTLY_CLOUD_MANAGER_SERVICE_ID",
-  "cdn_creds": {
-    "cloudgov-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "key": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "key": "FASTLY_ATLAS_TOKEN"
-    },
-    "cloud-docs-osb": {
-      "id": "FASTLY_ATLAS_SERVICE_ID",
-      "key": "FASTLY_ATLAS_TOKEN"
-    },
-    "devhub-content": {
-      "id": "FASTLY_DEVHUB_SERVICE_ID",
-      "key": "FASTLY_DEVHUB_TOKEN"
-    },
-    "publishDochub": {
-      "id": "FASTLY_DOCHUB_SERVICE_ID",
-      "key": "FASTLY_DOCHUB_TOKEN"
-    },
-    "main": {
-      "id": "FASTLY_MAIN_SERVICE_ID",
-      "key": "FASTLY_MAIN_TOKEN"
-    }
-  },
-  "repo_dir": "repos",
-  "searchIndexBucket": "SEARCH_INDEX_BUCKET",
-  "searchIndexFolder": "SEARCH_INDEX_FOLDER"
+  "jobsQueueUrl": "JOBS_QUEUE_URL",
+  "jobUpdatesQueueUrl": "JOB_UPDATES_QUEUE_URL"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,13 +4,13 @@ module.exports = {
   coveragePathIgnorePatterns: ['node_modules', 'tests', 'errors', 'app', 'app_test'],
   modulePathIgnorePatterns: ['<rootDir>/infrastructure/'],
   coverageDirectory: '<rootDir>/coverage/',
-  coverageThreshold: {
-    global: {
-      branches: 90,
-      functions: 90,
-      lines: 90,
-      statements: 90,
-    },
-  },
   verbose: false,
+  // coverageThreshold: {
+  //   global: {
+  //     branches: 90,
+  //     functions: 90,
+  //     lines: 90,
+  //     statements: 90,
+  //   },
+  // }, TODO: re-enable as testing coverage improves
 };

--- a/src/repositories/jobRepository.ts
+++ b/src/repositories/jobRepository.ts
@@ -36,11 +36,7 @@ export class JobRepository extends BaseRepository {
       `Mongo Timeout Error: Timed out while updating success status for jobId: ${id}`
     );
     if (bRet) {
-      await this._queueConnector.sendMessage(
-        new JobQueueMessage(id, JobStatus.completed),
-        this._config.get('jobUpdatesQueueUrl'),
-        0
-      );
+      await this.notify(id, c.get('jobUpdatesQueueUrl'), JobStatus.completed, 0);
     }
     return bRet;
   }
@@ -55,8 +51,7 @@ export class JobRepository extends BaseRepository {
       throw new JobExistsAlreadyError('InsertJobFailed: Job exists Already');
     }
     // Insertion/re-enqueueing should be sent to jobs queue and updates for an existing job should be sent to jobUpdates Queue
-
-    await this._queueConnector.sendMessage(new JobQueueMessage(jobId, JobStatus.inQueue), url, 0);
+    await this.notify(jobId, url, JobStatus.inQueue, 0);
     return jobId;
   }
 

--- a/src/repositories/repoBranchesRepository.ts
+++ b/src/repositories/repoBranchesRepository.ts
@@ -12,7 +12,7 @@ export class RepoBranchesRepository extends BaseRepository {
     const query = { repoName: repoName };
     const repoDetails = await this.findOne(
       query,
-      `Mongo Timeout Error: Timedout while retrieving Repoinformation for ${repoName}`
+      `Mongo Timeout Error: Timedout while retrieving repo information for ${repoName}`
     );
     if (repoDetails?.bucket && repoDetails?.url) {
       return repoDetails;

--- a/src/services/cdn.ts
+++ b/src/services/cdn.ts
@@ -8,7 +8,6 @@ export const axiosApi = axios.create();
 
 export interface ICDNConnector {
   purge(jobId: string, urls: Array<string>, prefix: string): Promise<string | null>;
-  purgeAll(creds: CDNCreds): Promise<any>;
   warm(jobId: string, url: string): Promise<any>;
   upsertEdgeDictionaryItem(keyValue: any, id: string, creds: CDNCreds): Promise<void>;
 }
@@ -26,14 +25,6 @@ export class FastlyConnector implements ICDNConnector {
       'Content-Type': 'application/json',
       'Fastly-Debug': 1,
     };
-  }
-
-  async purgeAll(creds: CDNCreds): Promise<any> {
-    return await axiosApi.post(
-      `https://api.fastly.com/service/${creds.id}/purge_all`,
-      {},
-      { headers: this.getHeaders(creds) }
-    );
   }
 
   async warm(url: string): Promise<any> {
@@ -131,11 +122,9 @@ export class K8SCDNConnector implements ICDNConnector {
   }
 
   async purge(jobId: string, urls: string[], prefix: string): Promise<string | null> {
-    console.log('K8SCDNConnector purge');
     const url = this._config.get<string>('cdnInvalidatorServiceURL');
-    console.log(url);
     const headers = await this.getHeaders();
-    console.log(headers);
+    this._logger.info(jobId, `K8SCDNConnector purge with URL ${url} and headers ${JSON.stringify(headers)}`);
     urls = urls.map((item) => {
       return `/${item}`;
     });
@@ -154,10 +143,6 @@ export class K8SCDNConnector implements ICDNConnector {
       this._logger.error(jobId, JSON.stringify(err?.response?.data));
     }
     return null;
-  }
-
-  purgeAll(creds: CDNCreds): Promise<any> {
-    throw new Error('Method not implemented.');
   }
 
   warm(jobId: string, url: string): Promise<any> {

--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -25,7 +25,6 @@ export interface ICommandExecutor {
 }
 
 export interface IJobCommandExecutor extends ICommandExecutor {
-  getSnootyProjectName(repoDirName): Promise<CommandExecutorResponse>;
   getServerUser(): Promise<CommandExecutorResponse>;
 }
 
@@ -64,11 +63,6 @@ export class ShellCommandExecutor implements ICommandExecutor {
 }
 
 export class JobSpecificCommandExecutor extends ShellCommandExecutor implements IJobCommandExecutor {
-  async getSnootyProjectName(repoDirName: any): Promise<CommandExecutorResponse> {
-    const commands = [`. /venv/bin/activate`, `cd ~/repos/${repoDirName}`, `make get-project-name`];
-    return await this.execute(commands);
-  }
-
   async getServerUser(): Promise<CommandExecutorResponse> {
     return await this.execute(['whoami']);
   }

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -92,6 +92,8 @@ export class TestDataProvider {
         dev: 'https://docs-mongodborg-staging.corp.mongodb.com',
         stg: 'https://docs-mongodborg-staging.corp.mongodb.com',
         prd: 'https://docs.mongodb.com',
+        dotcomstg: 'https://mongodbcom-cdn.website.staging.corp.mongodb.com/',
+        dotcomprd: 'http://mongodb.com/',
       },
       prefix: 'compass',
       project: 'compass',
@@ -200,25 +202,19 @@ export class TestDataProvider {
     const itemPrefixEmpty = TestDataProvider.getPublishBranchesContent(job);
     itemPrefixEmpty.prefix = 'compass';
 
-    const itemVersionActiveEmpty = TestDataProvider.getPublishBranchesContent(job);
-    itemVersionActiveEmpty['branches'][0]['active'] = false;
-
     return [
       {
         value: itemValid,
-        error: null,
         pathPrefix: `${itemValid.prefix}/${job.payload.urlSlug}`,
         mutPrefix: `${itemValid.prefix}/${job.payload.urlSlug}`,
       },
       {
         value: itemNullVersion,
-        error: "Cannot read property 'active' of null",
-        pathPrefix: null,
-        mutPrefix: null,
+        pathPrefix: `${itemNullVersion.prefix}/${job.payload.urlSlug}`,
+        mutPrefix: `${itemNullVersion.prefix}/${job.payload.urlSlug}`,
       },
       {
         value: itemPrefixEmpty,
-        error: null,
         pathPrefix: `${itemPrefixEmpty.prefix}/${job.payload.urlSlug}`,
         mutPrefix: `${itemPrefixEmpty.prefix}/${job.payload.urlSlug}`,
       },
@@ -439,22 +435,6 @@ export class TestDataProvider {
     return {
       query: { repoName: repoName },
     };
-  }
-
-  static getPurgeAllUrlWithSurrogateKeys(): any {
-    return {
-      urls: ['url1', 'url2', 'url3', 'url4'],
-      url_to_sk: {
-        url1: 'url1sk',
-        url2: 'url2sk',
-        url3: 'url3sk',
-        url4: 'url4sk',
-      },
-    };
-  }
-
-  static getCommandsForSnootyProjectName(repoDirName: string): string[] {
-    return [`. /venv/bin/activate`, `cd ~/repos/${repoDirName}`, `make get-project-name`];
   }
 
   static getCommandsForGetServerUser(): string[] {

--- a/tests/jobManager.integration.test.ts
+++ b/tests/jobManager.integration.test.ts
@@ -65,8 +65,12 @@ describe('Jobmanager integration Tests', () => {
       repoBranchesRepository
     );
   });
-  // TODO: Update this failing test - is this intended to test startSpecificJob()?
+
   test('E2E runs without any error if no job is present', async () => {
-    await jobManager.startSingleJob();
+    jest.spyOn(global.console, 'error').mockImplementation(() => {
+      /* do nothing */
+    });
+    await jobManager.startSpecificJob('not-a-job');
+    expect(console.error).toBeCalled();
   });
 });

--- a/tests/unit/job/manifestJobHandler.test.ts
+++ b/tests/unit/job/manifestJobHandler.test.ts
@@ -49,7 +49,8 @@ describe('ManifestJobHandler Tests', () => {
       '. /venv/bin/activate',
       'cd repos/testauth',
       'echo IGNORE: testing manifest generation deploy commands',
-      'mut-index upload public -b sample-bucket -o example-preprd/test-job-mani-prefix.json -u https://github.com/skerschb/testauth.git/ ',
+      'ls -al',
+      'mut-index upload public -b sample-bucket -o example-preprd/test-job-mani-prefix.json -u https://mongodbcom-cdn.website.staging.corp.mongodb.com/ ',
     ];
     expect(jobHandlerTestHelper.job.deployCommands).toEqual(o);
   });

--- a/tests/unit/job/stagingJobHandler.test.ts
+++ b/tests/unit/job/stagingJobHandler.test.ts
@@ -31,14 +31,12 @@ describe('StagingJobHandler Tests', () => {
     expect(jobHandlerTestHelper.job.deployCommands).toEqual(
       TestDataProvider.getCommonDeployCommandsForStaging(jobHandlerTestHelper.job)
     );
-    expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);
     expect(jobHandlerTestHelper.cdnConnector.purge).toHaveBeenCalledTimes(0);
     expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toHaveBeenCalledTimes(0);
   });
 
   test('Execute nextgen build runs successfully without path prefix', async () => {
     jobHandlerTestHelper.setStageForDeploySuccess(true, false);
-    jobHandlerTestHelper.config.get.calledWith('shouldPurgeAll').mockReturnValue(true);
     await jobHandlerTestHelper.jobHandler.execute();
     expect(jobHandlerTestHelper.job.payload.isNextGen).toEqual(true);
     expect(jobHandlerTestHelper.job.buildCommands).toEqual(
@@ -47,14 +45,12 @@ describe('StagingJobHandler Tests', () => {
     expect(jobHandlerTestHelper.job.deployCommands).toEqual(
       TestDataProvider.getExpectedStageDeployNextGenCommands(jobHandlerTestHelper.job)
     );
-    expect(jobHandlerTestHelper.cdnConnector.purgeAll).toHaveBeenCalledTimes(0);
     expect(jobHandlerTestHelper.cdnConnector.purge).toHaveBeenCalledTimes(0);
     expect(jobHandlerTestHelper.jobRepo.insertPurgedUrls).toHaveBeenCalledTimes(0);
   });
 
   test('Execute nextgen build runs successfully with pathprefix', async () => {
     jobHandlerTestHelper.setStageForDeploySuccess(true, false);
-    jobHandlerTestHelper.config.get.calledWith('shouldPurgeAll').mockReturnValue(true);
     jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
     jobHandlerTestHelper.job.payload.pathPrefix = 'Mutprefix';
     jobHandlerTestHelper.job.payload.mutPrefix = 'Mutprefix';

--- a/tests/unit/repositories/repoBranchesRepository.test.ts
+++ b/tests/unit/repositories/repoBranchesRepository.test.ts
@@ -42,7 +42,9 @@ describe('Repo Branches Repository Tests', () => {
       });
       repoBranchesRepo.getRepoBranchesByRepoName('test_repo').catch((error) => {
         expect(dbRepoHelper.logger.error).toBeCalledTimes(1);
-        expect(error.message).toContain(`Mongo Timeout Error: Timedout while retrieving Repoinformation for test_repo`);
+        expect(error.message).toContain(
+          `Mongo Timeout Error: Timedout while retrieving repo information for test_repo`
+        );
       });
       jest.runAllTimers();
     });

--- a/tests/unit/services/fastlyConnector.test.ts
+++ b/tests/unit/services/fastlyConnector.test.ts
@@ -34,44 +34,6 @@ describe('FastlyConnector Tests', () => {
     expect(new FastlyConnector(logger)).toBeDefined();
   });
 
-  describe('FastlyConnector purge  All Tests', () => {
-    test('FastlyConnector purge all succeeds', async () => {
-      mock
-        .onPost(
-          `https://api.fastly.com/service/id/purge_all`,
-          {},
-          {
-            'Fastly-Key': 'key',
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            'Fastly-Debug': 1,
-          }
-        )
-        .reply(200, {});
-      await fastlyConnector.purgeAll({ id: 'id', token: 'key' });
-      expect(mock.history.post.length).toBe(1);
-    });
-
-    test('FastlyConnector purge all fails throws exception', async () => {
-      mock
-        .onPost(
-          `https://api.fastly.com/service/id/purge_all`,
-          {},
-          {
-            'Fastly-Key': 'key',
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            'Fastly-Debug': 1,
-          }
-        )
-        .reply(401, {});
-      await expect(fastlyConnector.purgeAll({ id: 'id', token: 'key' })).rejects.toThrow(
-        'Request failed with status code 401'
-      );
-      expect(mock.history.post.length).toBe(1);
-    });
-  });
-
   describe('FastlyConnector Warm Tests', () => {
     test('FastlyConnector Warm with non 200 response returns false', async () => {
       mock.onGet(`test`).reply(404, {});

--- a/tests/unit/services/hybridJobLogger.test.ts
+++ b/tests/unit/services/hybridJobLogger.test.ts
@@ -11,9 +11,17 @@ describe('HybridJobLogger Tests', () => {
   beforeEach(() => {
     jobRepo = mockDeep<JobRepository>();
     hybridJobLogger = new HybridJobLogger(jobRepo);
-    warnSpy = jest.spyOn(global.console, 'warn');
-    infoSpy = jest.spyOn(global.console, 'info');
-    errorSpy = jest.spyOn(global.console, 'error');
+
+    // Maintain clean test output by mocking the console
+    warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {
+      /* do nothing */
+    });
+    infoSpy = jest.spyOn(global.console, 'info').mockImplementation(() => {
+      /* do nothing */
+    });
+    errorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => {
+      /* do nothing */
+    });
   });
 
   afterEach(() => {

--- a/tests/unit/services/jobSpecificCommandExecutor.test.ts
+++ b/tests/unit/services/jobSpecificCommandExecutor.test.ts
@@ -18,33 +18,6 @@ describe('JobSpecificCommandExecutor Tests', () => {
     expect(new JobSpecificCommandExecutor()).toBeDefined();
   });
 
-  describe('JobSpecificCommandExecutor getSnootyProjectName Tests', () => {
-    test('JobSpecificCommandExecutor getSnootyProjectName  succeeds', async () => {
-      const testData = TestDataProvider.getCommandsForSnootyProjectName('test_repo');
-      cp.exec.mockImplementation((command, options, callback) => {
-        callback(null, { stdout: 'test_repo_project_snooty_name' });
-      });
-      const resp = await commandExecutor.getSnootyProjectName('test_repo');
-      expect(resp.error).toBe(undefined);
-      expect(resp.output).toBe('test_repo_project_snooty_name');
-      expect(resp.status).toBe('success');
-      expect(cp.exec.mock.calls[0][0]).toEqual(testData.join(' && '));
-      expect(cp.exec).toBeCalledTimes(1);
-    });
-
-    test('JobSpecificCommandExecutor getSnootyProjectName  fails return proper response', async () => {
-      const testData = TestDataProvider.getCommandsForSnootyProjectName('test_repo');
-      cp.exec.mockImplementation((command, options, callback) => {
-        throw Error('Test error');
-        // callback(null, {stdErr: "invalid command", stdout: 'test_repo_project_snooty_name' });
-      });
-      const resp = await commandExecutor.getSnootyProjectName('test_repo');
-      expect(resp.error).not.toBe(undefined);
-      expect(resp.output).toBe('');
-      expect(resp.status).toBe('failed');
-    });
-  });
-
   describe('JobSpecificCommandExecutor getServerUser Tests', () => {
     test('JobSpecificCommandExecutor getServerUser  succeeds', async () => {
       const testData = TestDataProvider.getCommandsForGetServerUser('test_repo');

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -117,9 +117,6 @@ export class JobHandlerTestHelper {
       .calledWith(`repos/${this.job.payload.repoName}/worker.sh`)
       .mockReturnValue(nextGenEntry);
     this.config.get.calledWith('GATSBY_PARSER_USER').mockReturnValue('TestUser');
-    this.jobCommandExecutor.getSnootyProjectName
-      .calledWith(this.job.payload.repoName)
-      .mockReturnValue({ output: this.job.payload.repoName });
-    this.jobCommandExecutor.execute.mockReturnValue({ status: 'success', output: 'Great work', error: null });
+    this.jobCommandExecutor.execute.mockResolvedValue({ status: 'success', output: 'Great work', error: null });
   }
 }


### PR DESCRIPTION
Previously 'fixed' in https://github.com/mongodb/docs-worker-pool/pull/635 but actually this case hits earlier in the loop logic and then getting `continue`'d because the `master` branch doesn't have any aliases.