### PR TITLE
Remove COMMIT_HASH from docs-landing Makefile

### DIFF
--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -7,8 +7,6 @@ PROJECT=landing
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
-COMMIT_HASH=$(shell git rev-parse --short HEAD)
-
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
@@ -25,7 +23,7 @@ get-build-dependencies:
 
 next-gen-html: build-legacy-pages
 	# snooty parse and then build-front-end
-	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" --commit "${COMMIT_HASH}" ${RSTSPEC_FLAG}; \
+	@echo ${SNOOTY_DB_PWD} | snooty build "${REPO_DIR}" "mongodb+srv://${SNOOTY_DB_USR}:@cluster0-ylwlz.mongodb.net/snooty?retryWrites=true" ${RSTSPEC_FLAG}; \
 	if [ $$? -eq 1 ]; then \
 		exit 1; \
 	else \
@@ -35,7 +33,6 @@ next-gen-html: build-legacy-pages
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
-	echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production; \
 	npm run build; \
 	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
 	mv build-legacy-pages/sitemap-index.xml public/
@@ -43,10 +40,10 @@ next-gen-html: build-legacy-pages
 	mv build-legacy-pages/cloud public/
 
 next-gen-stage:
-	mut-publish public ${BUCKET} --prefix="${COMMIT_HASH}/${MUT_PREFIX}" --stage ${ARGS};
-	echo "Hosted at ${URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
-	echo "Hosted at ${URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/cloud";
-	echo "Hosted at ${URL}/${COMMIT_HASH}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/tools";
+	mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS};
+	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
+	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/cloud";
+	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/tools";
 
 next-gen-deploy-search-index: # do not create search entry for docs-landing
 	@echo "Skipping search index, since landing should not be indexed."


### PR DESCRIPTION
Removing `COMMIT_HASH` since including the commit hash was causing build issues with snooty parser v0.13.6.