### PR TITLE
[DOP-2715] bucket polices and job filter

### DIFF
--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -249,6 +249,13 @@ async function SubmitArchiveJob(jobId: string) {
   const job = await models.jobs.getJobById(jobId);
   const repo = await models.branches.getRepo(job.payload.repoName);
 
+  /* NOTE
+   * we don't archive landing for two reasons:
+   * - we can't unless we add efs to batch for extra storage; or https://github.com/aws/containers-roadmap/issues/1383
+   * - other properties like realm are nested under s3
+   */
+  if (repo.repoName == 'docs-landing') return;
+
   const response = await new Batch(environment).submitArchiveJob(
     repo.bucket[environment],
     `docs-archive-${environment}-mongodb`,

--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -254,7 +254,8 @@ async function SubmitArchiveJob(jobId: string) {
    * - we can't unless we add efs to batch for extra storage; or https://github.com/aws/containers-roadmap/issues/1383
    * - other properties like realm are nested under s3
    */
-  if (repo.repoName == 'docs-landing') return;
+  const archiveExclusions = ['docs-landing'];
+  if (archiveExclusions.includes(repo.repoName)) return;
 
   const response = await new Batch(environment).submitArchiveJob(
     repo.bucket[environment],

--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -79,9 +79,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["DocsBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["DocsBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -106,9 +109,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["DocAtlasBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["DocAtlasBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -133,9 +139,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["CloudManagerBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["CloudManagerBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -160,9 +169,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["OpsManagerBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["OpsManagerBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -187,9 +199,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["JavaBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["JavaBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -214,9 +229,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["GoBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["GoBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
@@ -241,9 +259,12 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
-            Action: 's3:GetObject'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["NodeBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["NodeBucket", "Arn" ] }]]
           - Effect: Allow
             Principal:
               AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch


### PR DESCRIPTION
## Description
This PR updates the s3 bucker polices to allow the archive job to recursively copy files. In previous tests where we archive sites under the primary docs bucket, the job would succeed since the bucker policy allows `s3:ListBucket` to the public. The  other buckets like `atlas` don't have the same policy statement.

After talking with @casthewiz we also decided that it's ok to skip the archive process for `docs-landing` since the build for that site is relatively fast. `docs-landing` is hard to archive with our current s3 layout, since other sites end up nested under the same folder. For example if we archive `/docs` we also include `/docs/realm`.