### PR TITLE
Increase CPU units for prd instance

### DIFF
--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -44,7 +44,7 @@ custom:
     containerCpu:
       dev: '2048'
       stg: '2048'
-      prd: '4096'
+      prd: '8192'
       dotcomstg: '2048'
       dotcomprd: '4096'
     containerMemory:


### PR DESCRIPTION
Based on cursory investigation, Gatsby seems to make good use of additional CPUs and doesn't appear to be memory-bound. Testing out increasing the number of available CPUs on `prd` to assess its impact.