### PR TITLE
DOP-3338: remove old search manifest generation step from Makefiles

### DIFF
--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -14,21 +14,13 @@ PROJECT=cloud-docs
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
-CUSTOM_SEARCH_INDEX=true
-
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-INDEX_NAME=$(subst cloud-docs,atlas,${MANIFEST_PREFIX})
 
-next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${INDEX_NAME}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
-
-
-.PHONY: help stage fake-deploy deploy publish deploy-search-index remote-includes next-gen-html
+.PHONY: help stage fake-deploy deploy publish remote-includes next-gen-html
 
 help:
 	@echo 'Targets'

--- a/makefiles/Makefile.cloud-docs-osb
+++ b/makefiles/Makefile.cloud-docs-osb
@@ -11,14 +11,7 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
-CUSTOM_SEARCH_INDEX=true
-
 include ~/shared.mk
-
-
-next-gen-deploy-search-index:
-	@echo "Not building search index as part of this deploy"
-
 
 get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/cloud-docs-osb.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.cloudgov-docs
+++ b/makefiles/Makefile.cloudgov-docs
@@ -9,21 +9,12 @@ PROJECT=cloudgov
 MUT_PREFIX ?= $(PROJECT)
 REPO_DIR=$(shell pwd)
 
-CUSTOM_SEARCH_INDEX=true
-
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-INDEX_NAME=$(subst cloudgov,AtlasGov,${MANIFEST_PREFIX})
-
-next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${INDEX_NAME}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
-
-
-.PHONY: help stage fake-deploy deploy deploy-search-index publish remote-includes api-docs
+.PHONY: help stage fake-deploy deploy publish remote-includes api-docs
 
 
 get-build-dependencies: 

--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -15,8 +15,6 @@ SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
 
-CUSTOM_SEARCH_INDEX=true
-
 include ~/shared.mk
 
 DRIVERS_PATH=source/driver-examples
@@ -36,7 +34,7 @@ URL_APPENDIX=$(shell if [ ! -z "${PATCH_ID}" ]; then echo "_${PATCH_ID}"; fi)
 # the current "stable" branch. This is weird and dumb, yes.
 STABLE_BRANCH=`grep 'manual' build/docs-tools/data/manual-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
-.PHONY: help lint html markdown stage deploy deploy-search-index examples redirects
+.PHONY: help lint html markdown stage deploy examples redirects
 
 next-gen-html: examples get-build-dependencies
 	# snooty parse and then build-front-end
@@ -77,16 +75,6 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
-
-INDEX_NAME=$(subst docs,manual,${MANIFEST_PREFIX})
-INDEX_NAME=$(subst null,manual,${MANIFEST_PREFIX})
-ifeq ($(INDEX_NAME), "manual-manual")
-	INDEX_NAME="manual-v5.0"
-endif
-
-next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${INDEX_NAME}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
 
 get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs.yaml > ${REPO_DIR}/published-branches.yaml
@@ -140,7 +128,6 @@ deploy: build/public ## Deploy to the production bucket
 
 	@echo "Hosted at ${URL}/index.html"
 
-	$(MAKE) next-gen-deploy-search-index
 
 redirects:
 	if [ ${GIT_BRANCH} = master ]; then mut-redirects config/redirects -o build/public/.htaccess; fi

--- a/makefiles/Makefile.docs-atlas-cli
+++ b/makefiles/Makefile.docs-atlas-cli
@@ -16,7 +16,6 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 # Necessary to add the fetch-submodule dependency
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
-CUSTOM_SEARCH_INDEX=true
 
 include ~/shared.mk
 
@@ -58,12 +57,6 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
-
-INDEX_NAME=$(subst null,${PROJECT},${MANIFEST_PREFIX})
-
-next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${INDEX_NAME}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
 
 get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-mongocli.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs-k8s-operator
+++ b/makefiles/Makefile.docs-k8s-operator
@@ -23,7 +23,7 @@ include ~/shared.mk
 # the current "stable" branch. This is weird and dumb, yes.
 STABLE_BRANCH=`grep 'manual' build/docs-tools/data/${PROJECT}-published-branches.yaml | cut -d ':' -f 2 | grep -Eo '[0-9a-z.]+'`
 
-.PHONY: help html publish stage deploy deploy-search-index
+.PHONY: help html publish stage deploy
 
 
 
@@ -79,22 +79,4 @@ publish:
 get-build-dependencies: 
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-k8s-operator.yaml > ${REPO_DIR}/published-branches.yaml
 
-
-
-
-#################################################################
-####  DEPLOY KUBERNETES OPERATOR DOCUMENTATION TO PRODUCTION ####
-#################################################################
-
-stage: ## Host online for review
-	mut-publish build/${GIT_BRANCH}/html ${BUCKET} --prefix=${PROJECT} --stage ${ARGS}
-	@echo "Hosted at ${URL}/${PROJECT}/${USER}/${GIT_BRANCH}/index.html"
-
-## Deploy to the production bucket
-deploy: build/public
-	mut-publish build/public ${BUCKET} --prefix=${PROJECT} --deploy --redirect-prefix='${PROJECT}' ${ARGS}
-
-	@echo "\n\nHosted at ${URL}/${PROJECT}/index.html"
-
-	$(MAKE) next-gen-deploy-search-index
 

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -10,7 +10,6 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
-CUSTOM_SEARCH_INDEX=true
 
 include ~/shared.mk
 
@@ -44,9 +43,6 @@ next-gen-stage:
 	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/";
 	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/cloud";
 	echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/tools";
-
-next-gen-deploy-search-index: # do not create search entry for docs-landing
-	@echo "Skipping search index, since landing should not be indexed."
 
 build-legacy-pages:
 	@# Pull docs-tools updates

--- a/makefiles/Makefile.docs-meta
+++ b/makefiles/Makefile.docs-meta
@@ -9,8 +9,6 @@ REPO_DIR=$(shell pwd)
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
-CUSTOM_SEARCH_INDEX=true
-
 include ~/shared.mk
 
 # the following kept only since we've not dealt with removing the test logic in docs-worker-pool

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -16,7 +16,6 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 # Necessary to add the fetch-submodule dependency
 PUSHLESS_DEPLOY_SHARED_DISABLED=true
-CUSTOM_SEARCH_INDEX=true
 
 include ~/shared.mk
 
@@ -58,12 +57,6 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
-
-INDEX_NAME=$(subst null,${PROJECT},${MANIFEST_PREFIX})
-
-next-gen-deploy-search-index: ##THESE ARE TERRIBLE HACKS THAT WE SHOULD BE (AND ARE) ASHAMED OF
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${INDEX_NAME}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
 
 get-build-dependencies:
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-mongocli.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs-mongodb-vscode
+++ b/makefiles/Makefile.docs-mongodb-vscode
@@ -18,6 +18,3 @@ include ~/shared.mk
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-mongodb-vscode.yaml > ${REPO_DIR}/published-branches.yaml
 
-next-gen-deploy-search-index: ## Update the search index for this branch
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${PROJECT}-${GIT_BRANCH}.json -u "${URL}/${MUT_PREFIX}" -s

--- a/makefiles/Makefile.docs-node
+++ b/makefiles/Makefile.docs-node
@@ -17,7 +17,3 @@ include ~/shared.mk
 
 get-build-dependencies: 
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml
-
-next-gen-deploy-search-index: ## Update the search index for this branch
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${MANIFEST_PREFIX}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG}

--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -118,13 +118,3 @@ deploy: publish ## Deploy to the production bucket
 	mut-publish build/public ${BUCKET} --prefix=${PROJECT} --deploy ${ARGS}
 
 	@echo "Hosted at ${URL}/${PROJECT}/index.html"
-
-	$(MAKE) next-gen-deploy-search-index
-
-next-gen-deploy-search-index: ## Update the search index for this branch
-	@echo "Building search index"
-	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${URL}/${PROJECT}/${GIT_BRANCH} -g -s; \
-	else \
-		mut-index upload build/public/${GIT_BRANCH} -o docs-php-library-${GIT_BRANCH}.json -u ${URL}/${PROJECT}/${GIT_BRANCH} -s; \
-	fi

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -87,16 +87,6 @@ deploy: build/public ## Deploy to the production bucket
 
 	@echo "Hosted at ${URL}/index.html"
 
-	$(MAKE) next-gen-deploy-search-index
-
-next-gen-deploy-search-index: ## Update the search index for this branch
-	@echo "Building search index"
-	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/${GIT_BRANCH} -o manual-current.json --aliases manual-${GIT_BRANCH} -u ${URL}/manual -g -s; \
-	else \
-		mut-index upload build/public/${GIT_BRANCH} -o manual-${GIT_BRANCH}.json -u ${URL}/${GIT_BRANCH} -s; \
-	fi
-
 next-gen-html: examples
 	# snooty parse and then build-front-end
 	@if [ ! -z "${PATCH_ID}" ]; then \

--- a/makefiles/Makefile.mms-docs
+++ b/makefiles/Makefile.mms-docs
@@ -55,7 +55,7 @@ STABLE_BRANCH=`grep 'manual' build/docs-tools/data/mms-published-branches.yaml |
 
 ## I doubt that we'll ever have files named stage-cloud,
 ## fake-deploy-cloud, ... but eh
-.PHONY: help html publish publish-cloud publish-onprem stage-cloud fake-deploy-cloud deploy-cloud stage-onprem fake-deploy-onprem deploy-onprem deploy-opsmgr-current deploy-opsmgr-upcoming deploy-cloud-search-index deploy-opsmgr-search-index
+.PHONY: help html publish publish-cloud publish-onprem stage-cloud stage-onprem 
 
 
 
@@ -160,31 +160,6 @@ fake-deploy-cloud: build/public/cloud
 
 
 ##########################################################
-#### DEPLOY CLOUD MANAGER DOCUMENTATION TO PRODUCTION ####
-##########################################################
-
-## Deploy Cloud Manager to the production S3 bucket
-deploy-cloud: build/public/cloud
-ifneq ($(GIT_BRANCH), master)
-	$(error "Aborting attempt to deploy cloud on master")
-endif
-
-	mut-publish build/public/cloud ${PRODUCTION_BUCKET_CLOUDMGR} --prefix=${PREFIX} --deploy --all-subdirectories ${ARGS}
-
-	@echo "\n\nHosted at ${PRODUCTION_URL_CLOUDMGR}/index.html"
-
-	$(MAKE) deploy-cloud-search-index
-
-## Update the Cloud Manager search index
-deploy-cloud-search-index:
-ifneq ($(GIT_BRANCH), master)
-	$(error "Aborting attempt to deploy cloud on master")
-endif
-
-	mut-index upload build/public/cloud -o mms-cloud-${GIT_BRANCH}.json -u ${PRODUCTION_URL_CLOUDMGR} -g -s --exclude build/public/cloud/landing.html
-
-
-##########################################################
 ####                                                  ####
 ####         DEPLOY OPS MANAGER DOCUMENTATION         ####
 ####                                                  ####
@@ -210,25 +185,3 @@ fake-deploy-opsmgr: build/public/onprem
 	@echo "\n\nHosted at ${STAGING_URL_OPSMGR}/${GIT_BRANCH}/index.html"
 
 
-##########################################################
-#### DEPLOY CLOUD MANAGER DOCUMENTATION TO PRODUCTION ####
-##########################################################
-
-## Deploy Ops Manager to the production S3 bucket
-deploy-opsmgr: build/public/onprem
-	@echo "Copying over fullsize images "
-	cp source/figures/*fullsize.png build/public/onprem/${GIT_BRANCH}/_images/
-
-	mut-publish build/public/onprem/ ${PRODUCTION_BUCKET_OPSMGR} --prefix= --deploy  --redirects build/public/onprem/.htaccess ${ARGS}
-
-	@echo "\n\nHosted at ${PRODUCTION_URL_OPSMGR}/${GIT_BRANCH}/index.html"
-
-	$(MAKE) deploy-opsmgr-search-index
-
-## Update the Ops Manager search index
-deploy-opsmgr-search-index:
-	if [ ${STABLE_BRANCH} = ${GIT_BRANCH} ]; then \
-		mut-index upload build/public/onprem/${GIT_BRANCH} -o mms-onprem-current.json --aliases mms-onprem-${GIT_BRANCH} -u ${PRODUCTION_URL_OPSMGR}/current -g -s; \
-	else \
-		mut-index upload build/public/onprem/${GIT_BRANCH} -o mms-onprem-${GIT_BRANCH}.json -u ${PRODUCTION_URL_OPSMGR}/${GIT_BRANCH} -s; \
-	fi

--- a/makefiles/Makefile.realm-docs-sdk-java
+++ b/makefiles/Makefile.realm-docs-sdk-java
@@ -19,4 +19,3 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-INDEX_NAME=$(subst cloud-docs,atlas,${MANIFEST_PREFIX})

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -3,7 +3,7 @@ SNOOTY_ENV = $(shell printenv SNOOTY_ENV)
 REGRESSION = $(shell printenv REGRESSION)
 BUCKET = $(shell printenv BUCKET)
 URL = $(shell printenv URL)
-INTEGRATION_SEARCH_BUCKET=docs-search-indexes-integration
+
 # "PATCH_ID" related shell commands to manage commitless builds
 PATCH_FILE="myPatch.patch"
 PATCH_ID=$(shell if test -f "${PATCH_FILE}"; then git patch-id < ${PATCH_FILE} | cut -b 1-7; fi)
@@ -28,7 +28,6 @@ next-gen-deploy:
 	if [ -f config/redirects -a "${GIT_BRANCH}" = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=${URL} --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${URL}/${MUT_PREFIX}";
-	if [ ${MANIFEST_PREFIX} ]; then $(MAKE) next-gen-deploy-search-index; fi
 endif
 
 ifndef PUSHLESS_DEPLOY_SHARED_DISABLED
@@ -72,12 +71,3 @@ next-gen-stage: ## Host online for review
 	fi
 endif
 
-## Update the search index for this branch
-## HACK-Y WORKAROUNDS:
-## docs && cloud-docs && cloudgov && mongocli have own search indexes to rename their manifests because of a bug in the workerpool code
-## Landing doesn't have search at all.
-ifndef CUSTOM_SEARCH_INDEX
-next-gen-deploy-search-index:
-	@echo "Building search index"
-	mut-index upload public -b ${BUCKET} -o ${MANIFEST_PREFIX}.json -u ${URL}/${MUT_PREFIX} -s ${GLOBAL_SEARCH_FLAG} $(BUCKET_FLAG)
-endif


### PR DESCRIPTION
As of earlier this year, search manifest generation is handled by manifest build jobs rather than as a step in the Makefile. This has proven efficient and effective and stable, so we should remove this extraneous build step. Moreover, continued support of this build stage (which serves no purpose) is blocking progress on updating `mut` for manifest jobs.

The analogous changes have [already happened in cloud-docs-osb for testing purposes](https://github.com/mongodb/docs-worker-pool/commit/541ab6e810467a6cda2e772a1b7f0121a537f999), which behaved as expected ([staging link](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=63596a79dafcf7c33d890275)). 

Given that Makefile changes are scary, though, extra attention to review detail would be appreciated :) 