### PR TITLE
DOP-3413: Add command for OAS Page Builder module

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -73,6 +73,9 @@ next-gen-stage: ## Host online for review
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
 
+# Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
+# Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
+# Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 endif

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -72,5 +72,8 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
+
+oas-page-build:
+	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 endif
 


### PR DESCRIPTION
### Ticket

[DOP-3413](https://jira.mongodb.org/browse/DOP-3413)

### Notes

* Adds new command to make the OAS Page Builder module callable
* This should be safe to keep since it will be uncalled at the moment. If we don't end up moving forward with the module implementation, this can be easily reverted
* `OAS_MODULE_PATH` and `REDOC_PATH` aren't declared in the Makefile atm. Going to look into adding/declaring them as part of the `Dockerfile` setup for the module and Redoc fork
* `make oas-page-build` is to be called as a build command by the autobuilder after `next-gen-html` for [staging jobs](https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57) and [production jobs](https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68) so that it can be done after frontend files are built, but before those files are uploaded by mut.