### PR TITLE
Generalize oas-page-build target

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -72,11 +72,11 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
+endif
 
 # Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
-endif
 


### PR DESCRIPTION
Brings `oas-page-build` outside of the if statement checking for `PUSHLESS_DEPLOY_SHARED_DISABLED`. I totally forgot that I would need to add this to specific Makefiles with custom build targets. 

This change keeps the build target generalized and calls the OAS Page Builder module with every docs build. If the docs repo being built does not have any OpenAPI pages, then the module exits early, meaning it should be safe to have and call. If we need more specific instances of this target, we should look into re-adding within the if statement