### PR TITLE
DOP-3377: add makefile command for persistence module

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -80,3 +80,5 @@ endif
 oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 
+persist-data:
+	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}


### PR DESCRIPTION
creating a make command for autobuilder to call in staging / production jobs

subsequent callers of this make command should be setting the var `PERSISTENCE_MODULE_PATH` within an env variable.