### PR TITLE
DOP-3377: update makefiles to invoke persistence module

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -54,6 +54,9 @@ next-gen-parse: examples
 	fi
 
 next-gen-html:  get-build-dependencies next-gen-parse 
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-atlas-cli
+++ b/makefiles/Makefile.docs-atlas-cli
@@ -38,6 +38,9 @@ next-gen-parse: fetch-submodule
 	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -28,6 +28,9 @@ next-gen-html: build-legacy-pages
 	else \
 		exit 0; \
 	fi
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -38,6 +38,9 @@ next-gen-parse: fetch-submodule
 	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -42,6 +42,9 @@ next-gen-parse: examples
 	fi
 
 next-gen-html: get-build-dependencies next-gen-parse 
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal-base
+++ b/makefiles/Makefile.docs-mongodb-internal-base
@@ -41,6 +41,9 @@ next-gen-parse: examples
 	fi
 
 next-gen-html: get-build-dependencies next-gen-parse 
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongoid
+++ b/makefiles/Makefile.docs-mongoid
@@ -34,6 +34,9 @@ next-gen-parse: get-build-dependencies
 	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -34,6 +34,9 @@ next-gen-parse: get-build-dependencies
 	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -34,6 +34,9 @@ next-gen-parse: get-build-dependencies
 	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -104,6 +104,9 @@ next-gen-html: examples
 			exit 0; \
 		fi \
 	fi
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR} && \
 	cd snooty && \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production && \

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -3,7 +3,6 @@ SNOOTY_ENV = $(shell printenv SNOOTY_ENV)
 REGRESSION = $(shell printenv REGRESSION)
 BUCKET = $(shell printenv BUCKET)
 URL = $(shell printenv URL)
-USE_PERSISTENCE = $(shell printenv USE_PERSISTENCE)
 
 # "PATCH_ID" related shell commands to manage commitless builds
 PATCH_FILE="myPatch.patch"

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -52,7 +52,7 @@ next-gen-parse:
 next-gen-html: next-gen-parse
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -48,17 +48,12 @@ next-gen-parse:
 		else \
 			exit 0; \
 		fi \
-	fi && \
-
-	# persistence module - add bundle zip to Atlas documents
-	if [ -n "$USE_PERSISTENCE" ]; then \
-		# ignore errors "-" flag
-		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}; \
-	else  \
-		echo "Skipping persistence module - missing USE_PERSISTENCE flag"; \
-	fi 
+	fi
 
 next-gen-html: next-gen-parse
+	# persistence module - add bundle zip to Atlas documents
+	# ignore errors "-" flag
+	-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH};
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -81,4 +81,8 @@ oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 
 persist-data:
-	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	ifeq ($(USE_PERSISTENCE), true)
+		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	else
+		echo "Skipping persistence module - missing USE_PERSISTENCE flag"
+	endif

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -53,7 +53,7 @@ next-gen-parse:
 next-gen-html: next-gen-parse
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH};
+	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -80,7 +80,7 @@ endif
 oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 
-persist-data:
+persist-data: next-gen-parse
 	ifeq ($(USE_PERSISTENCE), true)
 		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	else

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -49,6 +49,14 @@ next-gen-parse:
 		fi \
 	fi
 
+	# persistence module - add bundle zip to Atlas documents
+	ifeq ($(USE_PERSISTENCE), true)
+		# ignore errors "-" flag
+		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	else
+		echo "Skipping persistence module - missing USE_PERSISTENCE flag"
+	endif
+
 next-gen-html: next-gen-parse
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
@@ -72,14 +80,6 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
-
-persist-data: next-gen-parse
-	ifeq ($(USE_PERSISTENCE), true)
-		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
-	else
-		echo "Skipping persistence module - missing USE_PERSISTENCE flag"
-	endif
-
 endif
 
 # Intended to be called by the autobuilder as a build command after frontend build, but before mut upload

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -72,13 +72,6 @@ next-gen-stage: ## Host online for review
 		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
 		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
 	fi
-endif
-
-# Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
-# Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
-# Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
-oas-page-build:
-	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
 
 persist-data: next-gen-parse
 	ifeq ($(USE_PERSISTENCE), true)
@@ -86,3 +79,11 @@ persist-data: next-gen-parse
 	else
 		echo "Skipping persistence module - missing USE_PERSISTENCE flag"
 	endif
+
+endif
+
+# Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
+# Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
+# Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
+oas-page-build:
+	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -83,3 +83,4 @@ endif
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
+

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -3,6 +3,7 @@ SNOOTY_ENV = $(shell printenv SNOOTY_ENV)
 REGRESSION = $(shell printenv REGRESSION)
 BUCKET = $(shell printenv BUCKET)
 URL = $(shell printenv URL)
+USE_PERSISTENCE = $(shell printenv USE_PERSISTENCE)
 
 # "PATCH_ID" related shell commands to manage commitless builds
 PATCH_FILE="myPatch.patch"
@@ -50,12 +51,12 @@ next-gen-parse:
 	fi
 
 	# persistence module - add bundle zip to Atlas documents
-	ifeq ($(USE_PERSISTENCE), true)
+	if [ -n "$USE_PERSISTENCE" ]; then \
 		# ignore errors "-" flag
-		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
-	else
-		echo "Skipping persistence module - missing USE_PERSISTENCE flag"
-	endif
+		-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}; \
+	else  \
+		echo "Skipping persistence module - missing USE_PERSISTENCE flag"; \
+	fi 
 
 next-gen-html: next-gen-parse
 	# build-front-end after running parse commands

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -53,7 +53,7 @@ next-gen-parse:
 next-gen-html: next-gen-parse
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH};
+	node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH};
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -52,7 +52,7 @@ next-gen-parse:
 next-gen-html: next-gen-parse
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -48,7 +48,7 @@ next-gen-parse:
 		else \
 			exit 0; \
 		fi \
-	fi
+	fi && \
 
 	# persistence module - add bundle zip to Atlas documents
 	if [ -n "$USE_PERSISTENCE" ]; then \


### PR DESCRIPTION
Invoke persistence module [installed via Docker images](https://github.com/mongodb/docs-worker-pool/pull/737) as a step after parser.

See test build logs in above PR.
[Errors are ignored and build steps continue after non terminal error from persistence module](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=63c1bc44c5cd20791001d2ec)