### PR TITLE
Quick fix: point asset service to asset collection

### DIFF
--- a/modules/persistence/src/services/assets/index.ts
+++ b/modules/persistence/src/services/assets/index.ts
@@ -1,7 +1,7 @@
 import AdmZip from 'adm-zip';
 import { upsert } from '../connector';
 
-const COLLECTION_NAME = 'documents';
+const COLLECTION_NAME = 'assets';
 
 // Service responsible for upsertion of any image or blob assets.
 


### PR DESCRIPTION
- Persistence module was storing `/assets/<entryname>` from manifest zipfile in `documents` collection instead of designated `assets` collection. thanks @rayangler for the catch!