### PR TITLE
DOP-3462:  Delete unused env vars

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -21,8 +21,6 @@
   "fastlyCloudManagerServiceId": "FASTLY_CLOUD_MANAGER_SERVICE_ID",
   "gatsbyBaseUrl": "GATSBY_BASE_URL",
   "previewBuildEnabled": "PREVIEW_BUILD_ENABLED",
-  "gatsbyConsitentNavFlag": "GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION",
-  "gatsbySDKVersionDropdownFlag": "GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN",
   "repoBranchesCollection": "REPO_BRANCHES_COL_NAME",
   "repo_dir": "repos",
   "jobId": "jobId",

--- a/config/default.json
+++ b/config/default.json
@@ -13,8 +13,6 @@
   "fastlyDochubMap": "devfslydochubmap",
   "entitlementCollection": "entitlements",
   "reposBranchesCollection": "allison_repos_branches",
-  "gatsbyConsitentNavFlag": "true",
-  "gatsbySDKVersionDropdownFlag": "true",
   "MONGO_TIMEOUT_S": 15,
   "JOB_TIMEOUT_S": 900,
   "RETRY_TIMEOUT_MS": 5000,

--- a/config/test.json
+++ b/config/test.json
@@ -13,8 +13,6 @@
   "fastlyDochubMap": "devfslydochubmap",
   "entitlementCollection": "entitlements",
   "reposBranchesCollection": "allison_repos_branches",
-  "gatsbyConsitentNavFlag": "true",
-  "gatsbySDKVersionDropdownFlag": "true",
   "MONGO_TIMEOUT_S": 1,
   "JOB_TIMEOUT_S": 10,
   "RETRY_TIMEOUT_MS": 10,

--- a/infrastructure/ecs-main/ecs_service.yml
+++ b/infrastructure/ecs-main/ecs_service.yml
@@ -60,10 +60,6 @@ Resources:
               Value: ${self:custom.gatsbyBaseUrl}
             - Name: PREVIEW_BUILD_ENABLED
               Value: ${self:custom.previewBuildEnabled}
-            - Name: GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION
-              Value: ${self:custom.gatsbyFeatureFlagConsistentNavigation}
-            - Name: GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN
-              Value: ${self:custom.gatsbyFeatureFlagVersionDropdown}
             - Name: FASTLY_MAIN_TOKEN
               Value: ${self:custom.fastlyMainToken}
             - Name: FASTLY_MAIN_SERVICE_ID

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -173,34 +173,6 @@ export class TestDataProvider {
   static getEnvVarsWithPathPrefixWithFlags(job: Job): string {
     return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\n`;
   }
-  static getEnvVarsTestCases(): Array<any> {
-    return [
-      {
-        GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION: true,
-        GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN: true,
-        navString: 'TRUE',
-        versionString: 'TRUE',
-      },
-      {
-        GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION: true,
-        GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN: false,
-        navString: 'TRUE',
-        versionString: null,
-      },
-      {
-        GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION: false,
-        GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN: true,
-        navString: null,
-        versionString: 'TRUE',
-      },
-      {
-        GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION: false,
-        GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN: false,
-        navString: null,
-        versionString: null,
-      },
-    ];
-  }
 
   static getPathPrefixCases(): Array<any> {
     const job = getBuildJobDef();

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -158,28 +158,18 @@ describe('ProductionJobHandler Tests', () => {
     });
   });
 
-  describe.each(TestDataProvider.getEnvVarsTestCases())('Validate all set env var cases', (element) => {
+  test('Validate set env var cases', (element) => {
     test(`Testing commit check returns ${JSON.stringify(element)}`, async () => {
       jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
       jobHandlerTestHelper.job.payload.aliased = true;
       jobHandlerTestHelper.job.payload.primaryAlias = null;
       jobHandlerTestHelper.setupForSuccess();
-      jobHandlerTestHelper.config.get
-        .calledWith('GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION')
-        .mockReturnValue(element['GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION']);
-      jobHandlerTestHelper.config.get
-        .calledWith('GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN')
-        .mockReturnValue(element['GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN']);
       await jobHandlerTestHelper.jobHandler.execute();
       jobHandlerTestHelper.verifyNextGenSuccess();
       // TODO: Correct number of arguments
       expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
         `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
-        TestDataProvider.getEnvVarsWithPathPrefixWithFlags(
-          jobHandlerTestHelper.job,
-          element['navString'],
-          element['versionString']
-        ),
+        TestDataProvider.getEnvVarsWithPathPrefixWithFlags(jobHandlerTestHelper.job),
         { encoding: 'utf8', flag: 'w' }
       );
     });

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -158,21 +158,19 @@ describe('ProductionJobHandler Tests', () => {
     });
   });
 
-  test('Validate set env var cases', (element) => {
-    test(`Testing commit check returns ${JSON.stringify(element)}`, async () => {
-      jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
-      jobHandlerTestHelper.job.payload.aliased = true;
-      jobHandlerTestHelper.job.payload.primaryAlias = null;
-      jobHandlerTestHelper.setupForSuccess();
-      await jobHandlerTestHelper.jobHandler.execute();
-      jobHandlerTestHelper.verifyNextGenSuccess();
-      // TODO: Correct number of arguments
-      expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
-        `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
-        TestDataProvider.getEnvVarsWithPathPrefixWithFlags(jobHandlerTestHelper.job),
-        { encoding: 'utf8', flag: 'w' }
-      );
-    });
+  test('Validate set env var case', async () => {
+    jobHandlerTestHelper.job.payload.repoBranches = TestDataProvider.getRepoBranchesData(jobHandlerTestHelper.job);
+    jobHandlerTestHelper.job.payload.aliased = true;
+    jobHandlerTestHelper.job.payload.primaryAlias = null;
+    jobHandlerTestHelper.setupForSuccess();
+    await jobHandlerTestHelper.jobHandler.execute();
+    jobHandlerTestHelper.verifyNextGenSuccess();
+    // TODO: Correct number of arguments
+    expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
+      `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
+      TestDataProvider.getEnvVarsWithPathPrefixWithFlags(jobHandlerTestHelper.job),
+      { encoding: 'utf8', flag: 'w' }
+    );
   });
 
   test('Default production deploy kicks off manifest generation', async () => {


### PR DESCRIPTION
### Ticket

[DOP-3462](https://jira.mongodb.org/browse/DOP-3462)

### Notes

`"GATSBY_FEATURE_FLAG_CONSISTENT_NAVIGATION"` and `"GATSBY_FEATURE_FLAG_SDK_VERSION_DROPDOWN"` are legacy env vars that are not utilized.

They both were commented out [on Oct 29, 2021 when](https://github.com/mongodb/docs-worker-pool/commit/11b582288a35a889a3eb9a7af3d4ccba6211b157#diff-bbcb862d598d250dee17e1ffba68a23d0b35425ff1be4b52eeb5a975e4ecff0b) `GatsbyAdapter.js` was consolidated into `jobHandler.ts`. Then later were fully taken out of `jobHandler.ts`.

The variables themselves and tests are still in the autobuilder code. This PR removes all references.

Subsequently, they will be removed from our AWS Parameter Store as well after merging.