### PR TITLE
DOP-3462-B: Cleanup env vars in serverless.yml

### DIFF
--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -102,8 +102,6 @@ custom:
   awsSecretDevhub: ${ssm:/env/${self:provider.stage}/docs/worker_pool/devhub/aws/secret}
   gatsbyBaseUrl: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/base_url}
   previewBuildEnabled: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/preview_build/enabled}
-  gatsbyFeatureFlagConsistentNavigation: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/consistent_nav/enabled}
-  gatsbyFeatureFlagVersionDropdown: false
   gatsbyTestEmbedVersions: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/embedded_versions}
   fastlyMainToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/token}
   fastlyMainServiceId: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/service_id}


### PR DESCRIPTION
### Ticket

[DOP-3462](https://jira.mongodb.org/browse/DOP-3462)

### Notes

This is a follow-on to [this ticket's original PR](https://github.com/mongodb/docs-worker-pool/pull/744). 

There was one more spot that the variables were referenced.