### PR TITLE
update concurrency and remove deploy dev on push

### DIFF
--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -1,14 +1,10 @@
 on:
-  push:
-    branches:
-      - "master"
-      - "integration"
   pull_request:
     branches:
       - master
       - integration
 concurrency:
-  group: environment-${{ github.ref }}
+  group: environment-dev-${{ github.ref }}
   cancel-in-progress: true
 name: Deploy Dev ECS
 jobs:

--- a/.github/workflows/deploy-prd-ecs.yml
+++ b/.github/workflows/deploy-prd-ecs.yml
@@ -3,7 +3,7 @@ on:
     tags:
       - 'v*'
 concurrency:
-  group: environment-${{ github.ref }}
+  group: environment-prd-${{ github.ref }}
   cancel-in-progress: true
 name: Deploy Production ECS
 jobs:

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -4,7 +4,7 @@ on:
       - "master"
       - "integration"
 concurrency:
-  group: environment-${{ github.ref }}
+  group: environment-stg-${{ github.ref }}
   cancel-in-progress: true
 name: Deploy Staging ECS
 jobs:


### PR DESCRIPTION
**Goal:** 
- update concurrency groups so that dev/stg/prd workflows can run in parallel
- remove dev deploy (unsure of purpose...) <- should we remove this completely? it hasn't been required ever, or successful in 4 months...