### PR TITLE
DOP-3384: Use snooty parser binary builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ARG SNOOTY_FRONTEND_VERSION=0.13.36
 # The Redoc CLI branch will most likely stay static. Updates to the branch should
 # be limited to CLI bug fixes and Redoc dependency version bumps
 ARG REDOC_CLI_VERSION=0.1.1
-ARG FLIT_VERSION=3.0.0
 ARG NPM_BASE_64_AUTH
 ARG NPM_EMAIL
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
* `apt install unzip` so we can extract the needful
* Remove the `FLIT_ROOT_INSTALL` environment variable, since we're no longer invoking `flit`
* Move the parser install logic to before the user is switched, so that we can install the parser to `/opt/snooty/`
* Add `/opt/snooty` to the system PATH so that `/opt/snooty/snooty` can be resolved
* Instead of git cloning and flit installing and all that jazz, just curl the salient parser release for linux x86_64, and unzip it in `/opt/`

Building the image succeeds, and confirmed `/opt/snooty/snooty` is accessible in the PATH.

Staged the server manual:
* https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=63d41e68cbd7d810f293c565
* https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/stable/