### PR TITLE
DOP-3404: Redirects for atlas cli v1.1*, v1.2*, and 1.3*

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -13,6 +13,66 @@ Resources:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}
                 ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/upcoming
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.3.0
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.3
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.2.1
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.2
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.2.0
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.2
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.7
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.6
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.5
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.4
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.3
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.2
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1.0
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.1
   DocAtlasBucket:
     Type: "AWS::S3::Bucket"
     Properties:


### PR DESCRIPTION
### Ticket

[DOP-3404](https://jira.mongodb.org/browse/DOP-3404)

### Notes

_Aside_: I weep as I open this pull request.
I researched and tried to find a way to use regex or wildcards for these, but those [don't seem to be possible](https://stackoverflow.com/questions/70304661/serverless-framework-how-to-use-wildcard-in-prefix-path) in the CloudFormation template. The only acceptable values for the [KeyPrefixEquals property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-routingrulecondition.html) are pure strings. 
It _might_ be worth trying to use a wildcard to see if it would work (`v1.1.*/`) because I have not found a definitive answer for this exact context, but if so, I'd like to try it only on `dotcomstg`.
**Note for future**: we are only allowed 50 such redirects. This PR moves us from 1 redirect to 11 redirects.


----
**Summary:**

`v1.1` and `v1.2` were found to have a large amount of `url aliases` set in the database ([Link to Hapley](https://hapley.corp.mongodb.com/repos/docs-atlas-cli)). This leads to multiple unnecessary builds. 
This PR adds the aforementioned aliases as simple redirects to our S3 bucket `RoutingRules`.

`v1.1.7`, `v1.1.6`, `v1.1.5`, `v1.1.4`, `v1.1.3`, `v1.1.2`, and `v1.1.0` now will all redirect to `v1.1`

`v1.2.1` and `v1.2.0` now will all redirect to `v1.2`

^ These were mentioned in the ticket, however I found that `v1.3` also [seems to have unnecessary aliases](https://hapley.corp.mongodb.com/repos/docs-atlas-cli/versions/6398fd2748e43bdf97398970).
I have made `v1.3.0` redirect to `v1.3`. If this is incorrect and I'm being greedy, let me know.

After this PR is merged and also deployed, I will delete all the offending aliases from the database. I will also delete the url aliases `v1.1`, `v1.2`, and `v1.3` because they are already used as the url slug for their respective versions.

I believe this is the correct order of operations - I should not delete the aliases until the redirects are live.