### PR TITLE
DOP-3480: unnest merged ToC children, and add node.options.urls

### DIFF
--- a/modules/persistence/src/services/metadata/ToC/index.ts
+++ b/modules/persistence/src/services/metadata/ToC/index.ts
@@ -47,15 +47,24 @@ const mergeNode = (node: ToC, tocs: ToCInsertions, currentProject) => {
   if (!associatedProject) return node;
   const branches = Object.keys(associatedProject);
   node.options.versions = branches;
-  node.children = branches.map((branch) => {
-    const child = needsUrlifiedToC ? associatedProject[branch].urlified : associatedProject[branch].original;
-    const options = {
-      ...child.options,
-      version: branch,
-    };
-    child.options = options;
-    return child;
-  });
+  node.options.urls = node.options.urls || {};
+  for (const branch of branches) {
+    node.options.urls[branch] = associatedProject[branch]['urlified']?.url;
+  }
+
+  node.children = branches.reduce((children: ToC[], branch) => {
+    // when merging ToC nodes, copy the nested children within the root node of associated product.
+    // we are skipping the root node that leads to '/' path within the project itself
+    const rootChild = needsUrlifiedToC ? associatedProject[branch].urlified : associatedProject[branch].original;
+    const copiedChildren = rootChild.children.map((originalNode: ToC) => {
+      originalNode.options = {
+        ...originalNode.options,
+        version: branch,
+      };
+      return originalNode;
+    });
+    return copiedChildren;
+  }, []);
   return node;
 };
 

--- a/modules/persistence/src/services/metadata/ToC/index.ts
+++ b/modules/persistence/src/services/metadata/ToC/index.ts
@@ -53,6 +53,17 @@ const mergeNode = (node: ToC, tocs: ToCInsertions, currentProject) => {
     node.options.urls[branch] = associatedProject[branch]['urlified']?.url;
   }
 
+  if (node.options?.project === currentProject) {
+    // this node is targeted to be this same project.
+    // update the slug to be the root slug.
+    node.slug = '/';
+    delete node.url;
+  } else {
+    // umbrella project targeting associated ToC node
+    // handle slugs with node.options.urls instead
+    delete node.slug;
+  }
+
   node.children = branches.reduce((children: ToC[], branch) => {
     // when merging ToC nodes, copy the nested children within the root node of associated product.
     // we are skipping the root node that leads to '/' path within the project itself

--- a/modules/persistence/src/services/metadata/index.ts
+++ b/modules/persistence/src/services/metadata/index.ts
@@ -37,7 +37,7 @@ export const insertMetadata = async (buildId: ObjectId, zip: AdmZip) => {
 
 export const insertMergedMetadataEntries = async (buildId: ObjectId, zip: AdmZip) => {
   try {
-    const mergedMetadataEntries = await mergeAssociatedToCs(metadataFromZip(zip)[0]);
+    const mergedMetadataEntries = await mergeAssociatedToCs(metadataFromZip(zip));
     return mergedMetadataEntries
       ? await Promise.all(mergedMetadataEntries.map((m) => insert([m], COLLECTION_NAME, buildId)))
       : [];

--- a/modules/persistence/tests/metadata/__snapshots__/ToC.test.ts.snap
+++ b/modules/persistence/tests/metadata/__snapshots__/ToC.test.ts.snap
@@ -15769,6 +15769,7 @@ Object {
             "master",
           ],
         },
+        "slug": "/",
         "title": Array [
           Object {
             "position": Object {

--- a/modules/persistence/tests/metadata/__snapshots__/ToC.test.ts.snap
+++ b/modules/persistence/tests/metadata/__snapshots__/ToC.test.ts.snap
@@ -15400,50 +15400,70 @@ Object {
       Object {
         "children": Array [
           Object {
+            "children": Array [],
+            "options": Object {
+              "drawer": true,
+              "version": "master",
+            },
+            "slug": "/",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 0,
+                  },
+                },
+                "type": "text",
+                "value": "Overview",
+              },
+            ],
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "slug": "compatibility",
+                "title": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Check Compatibility",
+                  },
+                ],
+              },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "slug": "install-atlas-cli",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Install or Update the Atlas CLI",
+              },
+            ],
+          },
+          Object {
             "children": Array [
               Object {
                 "children": Array [],
                 "options": Object {
                   "drawer": true,
                 },
-                "slug": "/",
-                "title": Array [
-                  Object {
-                    "position": Object {
-                      "start": Object {
-                        "line": 0,
-                      },
-                    },
-                    "type": "text",
-                    "value": "Overview",
-                  },
-                ],
-              },
-              Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "slug": "compatibility",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Check Compatibility",
-                      },
-                    ],
-                  },
-                ],
-                "options": Object {
-                  "drawer": false,
-                },
-                "slug": "install-atlas-cli",
+                "slug": "atlas-cli-save-connection-settings",
                 "title": Array [
                   Object {
                     "position": Object {
@@ -15452,71 +15472,16 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Install or Update the Atlas CLI",
+                    "value": "Save Connection Settings",
                   },
                 ],
               },
               Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "slug": "atlas-cli-save-connection-settings",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Save Connection Settings",
-                      },
-                    ],
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "slug": "atlas-cli-env-variables",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Atlas CLI Environment Variables",
-                      },
-                    ],
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "slug": "migrate-to-atlas-cli",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Migrate to the Atlas CLI",
-                      },
-                    ],
-                  },
-                ],
+                "children": Array [],
                 "options": Object {
                   "drawer": false,
                 },
-                "slug": "connect-atlas-cli",
+                "slug": "atlas-cli-env-variables",
                 "title": Array [
                   Object {
                     "position": Object {
@@ -15525,139 +15490,92 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Connect from the Atlas CLI",
+                    "value": "Atlas CLI Environment Variables",
                   },
                 ],
               },
               Object {
-                "children": Array [
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "slug": "migrate-to-atlas-cli",
+                "title": Array [
                   Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "slug": "telemetry",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Configure Telemetry",
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
                       },
-                    ],
+                    },
+                    "type": "text",
+                    "value": "Migrate to the Atlas CLI",
                   },
                 ],
+              },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "slug": "connect-atlas-cli",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Connect from the Atlas CLI",
+              },
+            ],
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "slug": "telemetry",
+                "title": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Configure Telemetry",
+                  },
+                ],
+              },
+            ],
+            "options": Object {
+              "drawer": true,
+              "version": "master",
+            },
+            "slug": "configure-optional-settings",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 3,
+                  },
+                },
+                "type": "text",
+                "value": "Configure Optional Settings",
+              },
+            ],
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
                 "options": Object {
                   "drawer": true,
                 },
-                "slug": "configure-optional-settings",
-                "title": Array [
-                  Object {
-                    "position": Object {
-                      "start": Object {
-                        "line": 3,
-                      },
-                    },
-                    "type": "text",
-                    "value": "Configure Optional Settings",
-                  },
-                ],
-              },
-              Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "slug": "atlas-cli-getting-started",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Get Started with ",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 0,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Atlas",
-                          },
-                        ],
-                        "name": "service",
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "substitution_reference",
-                      },
-                    ],
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "slug": "atlas-cli-quickstart",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Create and Configure an ",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 0,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Atlas",
-                          },
-                        ],
-                        "name": "service",
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "substitution_reference",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": " Cluster",
-                      },
-                    ],
-                  },
-                ],
-                "options": Object {
-                  "drawer": false,
-                },
-                "slug": "atlas-cli-tutorials",
+                "slug": "atlas-cli-getting-started",
                 "title": Array [
                   Object {
                     "position": Object {
@@ -15666,7 +15584,45 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Manage ",
+                    "value": "Get Started with ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 0,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Atlas",
+                      },
+                    ],
+                    "name": "service",
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "substitution_reference",
+                  },
+                ],
+              },
+              Object {
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "slug": "atlas-cli-quickstart",
+                "title": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Create and Configure an ",
                   },
                   Object {
                     "children": Array [
@@ -15695,53 +15651,65 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": " from the Atlas CLI",
+                    "value": " Cluster",
                   },
                 ],
+              },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "slug": "atlas-cli-tutorials",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Manage ",
               },
               Object {
                 "children": Array [
                   Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "slug": "cluster-config-file",
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Cluster Configuration File",
-                      },
-                    ],
-                  },
-                ],
-                "options": Object {
-                  "drawer": true,
-                },
-                "slug": "reference",
-                "title": Array [
-                  Object {
                     "position": Object {
                       "start": Object {
-                        "line": 3,
+                        "line": 0,
                       },
                     },
                     "type": "text",
-                    "value": "Reference",
+                    "value": "Atlas",
                   },
                 ],
+                "name": "service",
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "substitution_reference",
               },
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": " from the Atlas CLI",
+              },
+            ],
+          },
+          Object {
+            "children": Array [
               Object {
                 "children": Array [],
                 "options": Object {
-                  "drawer": false,
+                  "drawer": true,
                 },
-                "slug": "atlas-cli-changelog",
+                "slug": "cluster-config-file",
                 "title": Array [
                   Object {
                     "position": Object {
@@ -15750,30 +15718,53 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Atlas CLI Changelog",
+                    "value": "Cluster Configuration File",
                   },
                 ],
               },
             ],
             "options": Object {
+              "drawer": true,
               "version": "master",
             },
-            "slug": "/",
+            "slug": "reference",
             "title": Array [
               Object {
                 "position": Object {
                   "start": Object {
-                    "line": 0,
+                    "line": 3,
                   },
                 },
                 "type": "text",
-                "value": "Atlas Command Line Interface",
+                "value": "Reference",
+              },
+            ],
+          },
+          Object {
+            "children": Array [],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "slug": "atlas-cli-changelog",
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Atlas CLI Changelog",
               },
             ],
           },
         ],
         "options": Object {
           "project": "atlas-cli",
+          "urls": Object {
+            "master": "www.mongodb.com/docs/atlas/cli/",
+          },
           "versions": Array [
             "master",
           ],
@@ -49924,6 +49915,63 @@ Object {
       Object {
         "children": Array [
           Object {
+            "children": Array [],
+            "options": Object {
+              "drawer": true,
+              "version": "master",
+            },
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 0,
+                  },
+                },
+                "type": "text",
+                "value": "Overview",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "title": Array [
+                  Object {
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "text",
+                    "value": "Check Compatibility",
+                  },
+                ],
+                "url": "www.mongodb.com/docs/atlas/cli/compatibility",
+              },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Install or Update the Atlas CLI",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/install-atlas-cli",
+          },
+          Object {
             "children": Array [
               Object {
                 "children": Array [],
@@ -49934,36 +49982,17 @@ Object {
                   Object {
                     "position": Object {
                       "start": Object {
-                        "line": 0,
+                        "line": 4,
                       },
                     },
                     "type": "text",
-                    "value": "Overview",
+                    "value": "Save Connection Settings",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/",
+                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-save-connection-settings",
               },
               Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Check Compatibility",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/compatibility",
-                  },
-                ],
+                "children": Array [],
                 "options": Object {
                   "drawer": false,
                 },
@@ -49975,68 +50004,13 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Install or Update the Atlas CLI",
+                    "value": "Atlas CLI Environment Variables",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/install-atlas-cli",
+                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-env-variables",
               },
               Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Save Connection Settings",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-save-connection-settings",
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Atlas CLI Environment Variables",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-env-variables",
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Migrate to the Atlas CLI",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/migrate-to-atlas-cli",
-                  },
-                ],
+                "children": Array [],
                 "options": Object {
                   "drawer": false,
                 },
@@ -50048,32 +50022,71 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Connect from the Atlas CLI",
+                    "value": "Migrate to the Atlas CLI",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/connect-atlas-cli",
+                "url": "www.mongodb.com/docs/atlas/cli/migrate-to-atlas-cli",
               },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "title": Array [
               Object {
-                "children": Array [
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Connect from the Atlas CLI",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/connect-atlas-cli",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
+                "options": Object {
+                  "drawer": false,
+                },
+                "title": Array [
                   Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Configure Telemetry",
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
                       },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/telemetry",
+                    },
+                    "type": "text",
+                    "value": "Configure Telemetry",
                   },
                 ],
+                "url": "www.mongodb.com/docs/atlas/cli/telemetry",
+              },
+            ],
+            "options": Object {
+              "drawer": true,
+              "version": "master",
+            },
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 3,
+                  },
+                },
+                "type": "text",
+                "value": "Configure Optional Settings",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/configure-optional-settings",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [],
                 "options": Object {
                   "drawer": true,
                 },
@@ -50081,103 +50094,37 @@ Object {
                   Object {
                     "position": Object {
                       "start": Object {
-                        "line": 3,
+                        "line": 4,
                       },
                     },
                     "type": "text",
-                    "value": "Configure Optional Settings",
+                    "value": "Get Started with ",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "position": Object {
+                          "start": Object {
+                            "line": 0,
+                          },
+                        },
+                        "type": "text",
+                        "value": "Atlas",
+                      },
+                    ],
+                    "name": "service",
+                    "position": Object {
+                      "start": Object {
+                        "line": 4,
+                      },
+                    },
+                    "type": "substitution_reference",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/configure-optional-settings",
+                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-getting-started",
               },
               Object {
-                "children": Array [
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Get Started with ",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 0,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Atlas",
-                          },
-                        ],
-                        "name": "service",
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "substitution_reference",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-getting-started",
-                  },
-                  Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": false,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Create and Configure an ",
-                      },
-                      Object {
-                        "children": Array [
-                          Object {
-                            "position": Object {
-                              "start": Object {
-                                "line": 0,
-                              },
-                            },
-                            "type": "text",
-                            "value": "Atlas",
-                          },
-                        ],
-                        "name": "service",
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "substitution_reference",
-                      },
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": " Cluster",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-quickstart",
-                  },
-                ],
+                "children": Array [],
                 "options": Object {
                   "drawer": false,
                 },
@@ -50189,7 +50136,7 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Manage ",
+                    "value": "Create and Configure an ",
                   },
                   Object {
                     "children": Array [
@@ -50218,52 +50165,64 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": " from the Atlas CLI",
+                    "value": " Cluster",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-tutorials",
+                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-quickstart",
+              },
+            ],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Manage ",
               },
               Object {
                 "children": Array [
                   Object {
-                    "children": Array [],
-                    "options": Object {
-                      "drawer": true,
-                    },
-                    "title": Array [
-                      Object {
-                        "position": Object {
-                          "start": Object {
-                            "line": 4,
-                          },
-                        },
-                        "type": "text",
-                        "value": "Cluster Configuration File",
-                      },
-                    ],
-                    "url": "www.mongodb.com/docs/atlas/cli/cluster-config-file",
-                  },
-                ],
-                "options": Object {
-                  "drawer": true,
-                },
-                "title": Array [
-                  Object {
                     "position": Object {
                       "start": Object {
-                        "line": 3,
+                        "line": 0,
                       },
                     },
                     "type": "text",
-                    "value": "Reference",
+                    "value": "Atlas",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/reference",
+                "name": "service",
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "substitution_reference",
               },
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": " from the Atlas CLI",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-tutorials",
+          },
+          Object {
+            "children": Array [
               Object {
                 "children": Array [],
                 "options": Object {
-                  "drawer": false,
+                  "drawer": true,
                 },
                 "title": Array [
                   Object {
@@ -50273,31 +50232,54 @@ Object {
                       },
                     },
                     "type": "text",
-                    "value": "Atlas CLI Changelog",
+                    "value": "Cluster Configuration File",
                   },
                 ],
-                "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-changelog",
+                "url": "www.mongodb.com/docs/atlas/cli/cluster-config-file",
               },
             ],
             "options": Object {
+              "drawer": true,
               "version": "master",
             },
             "title": Array [
               Object {
                 "position": Object {
                   "start": Object {
-                    "line": 0,
+                    "line": 3,
                   },
                 },
                 "type": "text",
-                "value": "Atlas Command Line Interface",
+                "value": "Reference",
               },
             ],
-            "url": "www.mongodb.com/docs/atlas/cli/",
+            "url": "www.mongodb.com/docs/atlas/cli/reference",
+          },
+          Object {
+            "children": Array [],
+            "options": Object {
+              "drawer": false,
+              "version": "master",
+            },
+            "title": Array [
+              Object {
+                "position": Object {
+                  "start": Object {
+                    "line": 4,
+                  },
+                },
+                "type": "text",
+                "value": "Atlas CLI Changelog",
+              },
+            ],
+            "url": "www.mongodb.com/docs/atlas/cli/atlas-cli-changelog",
           },
         ],
         "options": Object {
           "project": "atlas-cli",
+          "urls": Object {
+            "master": "www.mongodb.com/docs/atlas/cli/",
+          },
           "versions": Array [
             "master",
           ],


### PR DESCRIPTION
**Goal:** 
1. when merging ToC nodes, we were previously including the root node of the associated product, which lead to a double nested ToC. **this PR unnests the children of the root node so that the associated product's root node's children are directly injected into the umbrella project's target node** 
2. given an associated product's root ToC can lead to two links (ie. https://www.mongodb.com/docs/atlas/cli/v1.3/ vs https://www.mongodb.com/docs/atlas/cli/stable), we need to be able to change the href of the ToC on the front end. **this PR adds an option to a ToC node. if it has node.options.versions: str[], it also has node.options.urls: {branchName: urlString}**


**Note:** 
Due to lack of clean up, ToC nodes front end ToC node's priorities will have to be updated so that a node's href is determined in order of:
- node.options.urls[currentVersion]
- node.options.url
- node.options.slug

