### PR TITLE
Ignore modules when formatting

### DIFF
--- a/modules/persistence/tests/data/metadata.json
+++ b/modules/persistence/tests/data/metadata.json
@@ -1111,20 +1111,12 @@
     "parentPaths": {
       "install-atlas-cli": [],
       "connect-atlas-cli": [],
-      "atlas-cli-save-connection-settings": [
-        "connect-atlas-cli"
-      ],
-      "atlas-cli-env-variables": [
-        "connect-atlas-cli"
-      ],
-      "migrate-to-atlas-cli": [
-        "connect-atlas-cli"
-      ],
+      "atlas-cli-save-connection-settings": ["connect-atlas-cli"],
+      "atlas-cli-env-variables": ["connect-atlas-cli"],
+      "migrate-to-atlas-cli": ["connect-atlas-cli"],
       "atlas-cli-quickstart": [],
       "reference": [],
-      "cluster-config-file": [
-        "reference"
-      ],
+      "cluster-config-file": ["reference"],
       "atlas-cli-changelog": []
     },
     "static_files": {},

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:fix": "npm run prettier -- --write",
     "lint": "eslint --ext .ts .",
     "lint:fix": "npm run lint -- --fix",
-    "prettier": "prettier '**/*.{js,jsx,json,md,ts}'",
+    "prettier": "prettier '**/*.{js,jsx,json,md,ts}' '!modules/**'",
     "prepare": "husky install"
   },
   "repository": {


### PR DESCRIPTION
`prettier` would catch unformatted files nested in the `modules/` directory, leading to potential errors in the GH Actions when running `npm run format` on the repo. 

This PR does the following:
* Uses `prettier` to format unformatted metadata json file in the persistence module. (Perhaps unnecessary given the bullet point below.)
* Ignores files nested in the `modules/` directory when formatting. This is consistent with the behavior for the root `.eslintrc.js` file.