### PR TITLE
Update Makefile.docs-mongodb-internal

### DIFF
--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -38,7 +38,7 @@ next-gen-parse: examples
 		fi \
 	fi
 
-next-gen-html: get-build-dependencies next-gen-parse 
+next-gen-html: next-gen-parse 
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
 	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}

--- a/makefiles/Makefile.docs-mongodb-internal-base
+++ b/makefiles/Makefile.docs-mongodb-internal-base
@@ -38,7 +38,7 @@ next-gen-parse: examples
 		fi \
 	fi
 
-next-gen-html: get-build-dependencies next-gen-parse 
+next-gen-html: next-gen-parse 
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
 	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}


### PR DESCRIPTION
Removes dangling reference to `get-build-dependencies`