### PR TITLE
Enable ToC merging into nodes with children

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - "master"
       - "integration"
+      - "embedded-atlas-cli-launch"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/modules/persistence/src/services/metadata/ToC/index.ts
+++ b/modules/persistence/src/services/metadata/ToC/index.ts
@@ -33,9 +33,11 @@ export interface TocOrderInsertions {
   };
 }
 
-const isInsertionCandidateNode = (node: ToC, associated_products: AssociatedProduct[] = []): boolean => {
-  const nodeInProducts = node.options?.project && associated_products.find((p) => p.name === node.options?.project);
-  const nodeHasNoChildren = !node.children || node.children.length === 0;
+const isInsertionCandidateNode = (node: ToC, toBeInserted: Set<string> = new Set([])): boolean => {
+  // TODO: STRONGLY RECONSIDER POST LAUNCH, SHOULD PREFER 'ATLAS CLI <|atlas-cli|>' and only node.options?.project
+  const projectName = node.options?.project || node.slug;
+  const nodeInProducts = node.options?.project && toBeInserted.has(projectName);
+  const nodeHasNoChildren = !node.children || node.children.length === 0 || !node.options?.project;
   return !!(nodeHasNoChildren && nodeInProducts);
 };
 
@@ -100,15 +102,16 @@ export const traverseAndMerge = (
   const { project } = metadata;
 
   const toctree = hasAssociations(metadata) ? umbrellaToCs.original : umbrellaToCs.urlified;
-
+  const toBeInserted = new Set(associated_products.map((p) => p.name));
   let queue = [toctree];
-  while (queue?.length) {
+  while (queue?.length && toBeInserted.size) {
     let next = queue.shift();
     // TODO: We can exit early here once we've found all the nodes.
     // We should track remaining insertions in a set and add some break logic.
-    if (next && isInsertionCandidateNode(next, associated_products)) {
+    if (next && isInsertionCandidateNode(next, toBeInserted)) {
       next = mergeNode(next, tocInsertions, project);
       metadata.toctreeorder = mergeTocTreeOrder(metadata, next, tocOrderInsertions);
+      toBeInserted.delete(next.options?.project);
     } else if (next?.children) {
       queue = [...queue, ...next.children];
     }

--- a/modules/persistence/src/services/metadata/ToC/index.ts
+++ b/modules/persistence/src/services/metadata/ToC/index.ts
@@ -34,11 +34,9 @@ export interface TocOrderInsertions {
 }
 
 const isInsertionCandidateNode = (node: ToC, toBeInserted: Set<string> = new Set([])): boolean => {
-  // TODO: STRONGLY RECONSIDER POST LAUNCH, SHOULD PREFER 'ATLAS CLI <|atlas-cli|>' and only node.options?.project
-  const projectName = node.options?.project || node.slug;
-  const nodeInProducts = node.options?.project && toBeInserted.has(projectName);
-  const nodeHasNoChildren = !node.children || node.children.length === 0;
-  return !!((nodeHasNoChildren && nodeInProducts) || (!node.options?.project && nodeInProducts));
+  const projectName = node.options?.project;
+  const nodeInProducts = projectName && toBeInserted.has(projectName);
+  return !!nodeInProducts;
 };
 
 const mergeNode = (node: ToC, tocs: ToCInsertions, currentProject) => {

--- a/modules/persistence/src/services/metadata/ToC/index.ts
+++ b/modules/persistence/src/services/metadata/ToC/index.ts
@@ -37,8 +37,8 @@ const isInsertionCandidateNode = (node: ToC, toBeInserted: Set<string> = new Set
   // TODO: STRONGLY RECONSIDER POST LAUNCH, SHOULD PREFER 'ATLAS CLI <|atlas-cli|>' and only node.options?.project
   const projectName = node.options?.project || node.slug;
   const nodeInProducts = node.options?.project && toBeInserted.has(projectName);
-  const nodeHasNoChildren = !node.children || node.children.length === 0 || !node.options?.project;
-  return !!(nodeHasNoChildren && nodeInProducts);
+  const nodeHasNoChildren = !node.children || node.children.length === 0;
+  return !!((nodeHasNoChildren && nodeInProducts) || (!node.options?.project && nodeInProducts));
 };
 
 const mergeNode = (node: ToC, tocs: ToCInsertions, currentProject) => {

--- a/modules/persistence/tests/metadata/ToC.test.ts
+++ b/modules/persistence/tests/metadata/ToC.test.ts
@@ -75,7 +75,7 @@ describe('ToC module', () => {
         if (candidate) break;
         candidate = findTargetToc([metadata[metadataIdx].toctree as unknown as ToC]);
       }
-      expect(_isInsertionCandidateNode(candidate, associatedProducts)).toBeTruthy();
+      expect(_isInsertionCandidateNode(candidate, new Set(associatedProducts.map((p) => p.name)))).toBeTruthy();
     });
 
     test('it returns false if node is not an associated product, or node has children', () => {
@@ -84,7 +84,7 @@ describe('ToC module', () => {
         if (candidate) break;
         candidate = findTargetToc([metadata[metadataIdx].toctree as unknown as ToC], false);
       }
-      expect(_isInsertionCandidateNode(candidate, associatedProducts)).toBeFalsy();
+      expect(_isInsertionCandidateNode(candidate, new Set(associatedProducts.map((p) => p.name)))).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
Enables the persistence module to merge ToC's and replace candidate insertion nodes even if that node has children.

Necessary for launch to accommodate a case for `atlas-cli`, and potentially necessary regardless. 

Ridealong to make BFS and candidate matching `Set` driven instead of doing list matching.