### PR TITLE
Close DB connection - oas-page-builder module

### DIFF
--- a/modules/oas-page-builder/index.ts
+++ b/modules/oas-page-builder/index.ts
@@ -6,6 +6,7 @@ import { getOASMetadata } from './src/services/buildMetadata';
 import { buildOpenAPIPages } from './src/services/pageBuilder';
 import { ModuleOptions } from './src/types';
 import { normalizeUrl } from './src/utils/normalizeUrl';
+import { teardown as closeDBConnection } from './src/services/database';
 
 const program = new Command();
 program
@@ -41,9 +42,11 @@ const app = async (options: ModuleOptions) => {
 app(options)
   .then(() => {
     console.log('Finished building OpenAPI content pages.');
+    closeDBConnection();
     process.exit(0);
   })
   .catch((e) => {
     console.error(e);
+    closeDBConnection();
     process.exit(1);
   });

--- a/modules/oas-page-builder/index.ts
+++ b/modules/oas-page-builder/index.ts
@@ -42,11 +42,10 @@ const app = async (options: ModuleOptions) => {
 app(options)
   .then(() => {
     console.log('Finished building OpenAPI content pages.');
-    closeDBConnection();
     process.exit(0);
   })
   .catch((e) => {
     console.error(e);
-    closeDBConnection();
     process.exit(1);
-  });
+  })
+  .finally(closeDBConnection);

--- a/modules/oas-page-builder/src/services/database.ts
+++ b/modules/oas-page-builder/src/services/database.ts
@@ -16,6 +16,10 @@ const client = new MongoClient(atlasURL);
 // cached db object, so we can handle initial connection process once if unitialized
 let dbInstance: Db;
 
+export const teardown = () => {
+  client.close();
+};
+
 const getDbName = () => {
   const env = process.env.SNOOTY_ENV ?? '';
 


### PR DESCRIPTION
No ticket.

Added teardown functionality to close DB connection at end of oas-page-builder module processes.