### PR TITLE
DOP-3613: Skip build step for redoc-cli

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - "master"
       - "integration"
-      # TODO-3613: Remove after testing
-      - "DOP-3613-built-cli-js"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - "master"
       - "integration"
+      # TODO-3613: Remove after testing
+      - "DOP-3613-built-cli-js"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM ubuntu:20.04
 ARG SNOOTY_PARSER_VERSION=0.13.18
 ARG SNOOTY_FRONTEND_VERSION=0.13.44
 ARG MUT_VERSION=0.10.3
-ARG REDOC_CLI_VERSION=1.1.1
+ARG REDOC_CLI_VERSION=1.1.2
 ARG NPM_BASE_64_AUTH
 ARG NPM_EMAIL
 ENV DEBIAN_FRONTEND=noninteractive
@@ -87,10 +87,7 @@ RUN git clone -b v${SNOOTY_FRONTEND_VERSION} --depth 1 https://github.com/mongod
 RUN git clone -b @dop/redoc-cli@${REDOC_CLI_VERSION} --depth 1 https://github.com/mongodb-forks/redoc.git redoc \
     # Install dependencies for Redoc CLI
     && cd redoc/ \
-    && npm ci --prefix cli/ --omit=dev \
-    # Install dependencies for Redoc component and building/compiling
-    && npm ci --omit=dev --ignore-scripts \
-    && npm run compile:cli
+    && npm ci --prefix cli/ --omit=dev
 
 COPY --from=ts-compiler /home/docsworker-xlarge/package*.json ./
 COPY --from=ts-compiler /home/docsworker-xlarge/config config/


### PR DESCRIPTION
### Ticket

[DOP-3613](https://jira.mongodb.org/browse/DOP-3613)

### Notes

* Moves the build step for `redoc-cli` as a release step in the redoc repo. The Dockerfile no longer needs to be responsible for building `redoc-cli`.
* Also updates the version of Redoc to include latest changes. These changes revolve around API versions and should not be expected to affect what's currently in production.
* Confirmed that test deploys are successful and OpenAPI pages are built. See build logs:
   * [cloud-docs](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=642dafca9bdad5e7f48c1100)
   * [atlas-app-services](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=642dafca9bdad5e7f48c1102)