### PR TITLE
DOP-3647: add makefile for Kotlin driver

### DIFF
--- a/makefiles/Makefile.docs-kotlin
+++ b/makefiles/Makefile.docs-kotlin
@@ -1,0 +1,19 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+USER=$(shell whoami)
+
+COMMIT_HASH=$(shell git rev-parse --short HEAD)
+
+PREFIX=drivers/kotlin
+PROJECT=kotlin
+MUT_PREFIX ?= $(PROJECT)
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+
+include ~/shared.mk
+
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml


### PR DESCRIPTION
Reminder that the get-build-dependencies step exists only so an autobuilder test passes, so I didn't bother to update the value. Hopefully we'll finish that ticket and get rid of those soon :) 