### PR TITLE
Use docs-builder-bot credentials for all git clone operations

### DIFF
--- a/src/services/repo.ts
+++ b/src/services/repo.ts
@@ -32,6 +32,7 @@ export class GitHubConnector implements IRepoConnector {
     this._fileSystemService = fileSystemService;
   }
 
+  // make everything use credentials to support "internal" repos
   private getBasePath(job: Job): string {
     const botName = this._config.get<string>('githubBotUserName');
     const botPw = this._config.get<string>('githubBotPW');

--- a/src/services/repo.ts
+++ b/src/services/repo.ts
@@ -35,7 +35,7 @@ export class GitHubConnector implements IRepoConnector {
   private getBasePath(job: Job): string {
     const botName = this._config.get<string>('githubBotUserName');
     const botPw = this._config.get<string>('githubBotPW');
-    return job.payload.private ? `https://${botName}:${botPw}@github.com` : 'https://github.com';
+    return `https://${botName}:${botPw}@github.com`;
   }
 
   async applyPatch(job: Job): Promise<any> {


### PR DESCRIPTION
By default, we assuming a repo is private if it's in the 10gen organization. This has largely worked, but isn't infallible, and mongodb/docs-kotlin is currently "internal", which is to say private outside of MongoDB but public within. Regardless, our colleagues need to be able to build it.

Having tested in integration, repos that are public and which do *not* have docs-builder-bot as a collaborator (e.g. mongodb/docs-compass) deploy correctly so this should do the needful.

As a follow-up we should figure out where "private" is used and whether we even need to keep that field. (I'll create a ticket).