### PR TITLE
DOP-3634: make sure tests cases are sorted

### DIFF
--- a/modules/persistence/jest-mongodb-config.js
+++ b/modules/persistence/jest-mongodb-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
-      version: '4.0.3',
+      version: '6.0.3',
       skipMD5: true,
     },
     autoStart: false,

--- a/modules/persistence/tests/metadata/ToC.test.ts
+++ b/modules/persistence/tests/metadata/ToC.test.ts
@@ -33,6 +33,8 @@ describe('ToC module', () => {
     try {
       connection = await MongoClient.connect(process.env.MONGO_URL || 'test');
       mockDb = await connection.db();
+      await mockDb.collection('repos_branches').deleteMany({});
+      await mockDb.collection('metadata').deleteMany({});
       await mockDb.collection('repos_branches').insertMany(repoBranches);
       await mockDb.collection('metadata').insertMany(metadata);
     } catch (e) {
@@ -41,8 +43,6 @@ describe('ToC module', () => {
   });
 
   afterAll(async () => {
-    await mockDb.collection('repos_branches').deleteMany({});
-    await mockDb.collection('metadata').deleteMany({});
     await connection.close();
   });
 

--- a/modules/persistence/tests/metadata/__snapshots__/associated_products.test.ts.snap
+++ b/modules/persistence/tests/metadata/__snapshots__/associated_products.test.ts.snap
@@ -129,6 +129,480 @@ Object {
 exports[`associated_products module getAssociatedProducts and shapeToCsCursor getAssociatedProducts returns an aggregation cursor for metadata, grouped by most recent build_id 1`] = `
 Object {
   "_id": Object {
+    "branch": "v1.0",
+    "project": "atlas-cli",
+  },
+  "most_recent": Object {
+    "_id": "63e2aa4d29d636971ac076c3",
+    "branch": "v1.0",
+    "build_id": Object {
+      "$oid": "63e2aa4c29d636971ac076ad",
+    },
+    "created_at": Object {
+      "$date": Object {
+        "$numberLong": "1675799116000",
+      },
+    },
+    "eol": false,
+    "parentPaths": Object {
+      "atlas-cli-changelog": Array [],
+      "atlas-cli-env-variables": Array [
+        "connect-atlas-cli",
+      ],
+      "atlas-cli-quickstart": Array [],
+      "atlas-cli-save-connection-settings": Array [
+        "connect-atlas-cli",
+      ],
+      "cluster-config-file": Array [
+        "reference",
+      ],
+      "connect-atlas-cli": Array [],
+      "install-atlas-cli": Array [],
+      "migrate-to-atlas-cli": Array [
+        "connect-atlas-cli",
+      ],
+      "reference": Array [],
+    },
+    "project": "atlas-cli",
+    "slugToTitle": Object {
+      "atlas-cli-changelog": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Atlas CLI Changelog",
+        },
+      ],
+      "atlas-cli-commands": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Atlas CLI Commands",
+        },
+      ],
+      "atlas-cli-env-variables": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Atlas CLI Environment Variables",
+        },
+      ],
+      "atlas-cli-quickstart": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Set Up ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 0,
+                },
+              },
+              "type": "text",
+              "value": "Atlas",
+            },
+          ],
+          "name": "service",
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "substitution_reference",
+        },
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": " with ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "atlas quickstart",
+            },
+          ],
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "literal",
+        },
+      ],
+      "atlas-cli-save-connection-settings": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Save Connection Settings",
+        },
+      ],
+      "cluster-config-file": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Cluster Configuration File",
+        },
+      ],
+      "connect-atlas-cli": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Connect from the Atlas CLI",
+        },
+      ],
+      "index": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 6,
+            },
+          },
+          "type": "text",
+          "value": "Atlas CLI",
+        },
+      ],
+      "install-atlas-cli": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Install or Update the Atlas CLI",
+        },
+      ],
+      "migrate-to-atlas-cli": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 4,
+            },
+          },
+          "type": "text",
+          "value": "Migrate to the Atlas CLI",
+        },
+      ],
+      "reference": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 3,
+            },
+          },
+          "type": "text",
+          "value": "Reference",
+        },
+      ],
+    },
+    "static_files": Object {},
+    "title": "Atlas Command Line Interface",
+    "toctree": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "options": Object {
+            "drawer": true,
+          },
+          "slug": "/",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 0,
+                },
+              },
+              "type": "text",
+              "value": "Overview",
+            },
+          ],
+        },
+        Object {
+          "children": Array [],
+          "options": Object {
+            "drawer": false,
+          },
+          "slug": "install-atlas-cli",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Install or Update the Atlas CLI",
+            },
+          ],
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "options": Object {
+                "drawer": true,
+              },
+              "slug": "atlas-cli-save-connection-settings",
+              "title": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Save Connection Settings",
+                },
+              ],
+            },
+            Object {
+              "children": Array [],
+              "options": Object {
+                "drawer": false,
+              },
+              "slug": "atlas-cli-env-variables",
+              "title": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Atlas CLI Environment Variables",
+                },
+              ],
+            },
+            Object {
+              "children": Array [],
+              "options": Object {
+                "drawer": false,
+              },
+              "slug": "migrate-to-atlas-cli",
+              "title": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Migrate to the Atlas CLI",
+                },
+              ],
+            },
+          ],
+          "options": Object {
+            "drawer": false,
+          },
+          "slug": "connect-atlas-cli",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Connect from the Atlas CLI",
+            },
+          ],
+        },
+        Object {
+          "children": Array [],
+          "options": Object {
+            "drawer": false,
+          },
+          "slug": "atlas-cli-quickstart",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Set Up ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 0,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Atlas",
+                },
+              ],
+              "name": "service",
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "substitution_reference",
+            },
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": " with ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "atlas quickstart",
+                },
+              ],
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "literal",
+            },
+          ],
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "options": Object {
+                "drawer": true,
+              },
+              "slug": "cluster-config-file",
+              "title": Array [
+                Object {
+                  "position": Object {
+                    "start": Object {
+                      "line": 4,
+                    },
+                  },
+                  "type": "text",
+                  "value": "Cluster Configuration File",
+                },
+              ],
+            },
+          ],
+          "options": Object {
+            "drawer": true,
+          },
+          "slug": "reference",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 3,
+                },
+              },
+              "type": "text",
+              "value": "Reference",
+            },
+          ],
+        },
+        Object {
+          "children": Array [],
+          "options": Object {
+            "drawer": false,
+          },
+          "slug": "atlas-cli-changelog",
+          "title": Array [
+            Object {
+              "position": Object {
+                "start": Object {
+                  "line": 4,
+                },
+              },
+              "type": "text",
+              "value": "Atlas CLI Changelog",
+            },
+          ],
+        },
+      ],
+      "slug": "/",
+      "title": Array [
+        Object {
+          "position": Object {
+            "start": Object {
+              "line": 0,
+            },
+          },
+          "type": "text",
+          "value": "Atlas Command Line Interface",
+        },
+      ],
+    },
+    "toctreeOrder": Array [
+      "/",
+      "/",
+      "install-atlas-cli",
+      "connect-atlas-cli",
+      "atlas-cli-save-connection-settings",
+      "atlas-cli-env-variables",
+      "migrate-to-atlas-cli",
+      "atlas-cli-quickstart",
+      "reference",
+      "cluster-config-file",
+      "atlas-cli-changelog",
+    ],
+  },
+}
+`;
+
+exports[`associated_products module getAssociatedProducts and shapeToCsCursor getAssociatedProducts returns an aggregation cursor for metadata, grouped by most recent build_id 2`] = `
+Object {
+  "_id": Object {
     "branch": "master",
     "project": "atlas-cli",
   },
@@ -815,480 +1289,6 @@ Object {
       "telemetry",
       "atlas-cli-tutorials",
       "atlas-cli-getting-started",
-      "atlas-cli-quickstart",
-      "reference",
-      "cluster-config-file",
-      "atlas-cli-changelog",
-    ],
-  },
-}
-`;
-
-exports[`associated_products module getAssociatedProducts and shapeToCsCursor getAssociatedProducts returns an aggregation cursor for metadata, grouped by most recent build_id 2`] = `
-Object {
-  "_id": Object {
-    "branch": "v1.0",
-    "project": "atlas-cli",
-  },
-  "most_recent": Object {
-    "_id": "63e2aa4d29d636971ac076c3",
-    "branch": "v1.0",
-    "build_id": Object {
-      "$oid": "63e2aa4c29d636971ac076ad",
-    },
-    "created_at": Object {
-      "$date": Object {
-        "$numberLong": "1675799116000",
-      },
-    },
-    "eol": false,
-    "parentPaths": Object {
-      "atlas-cli-changelog": Array [],
-      "atlas-cli-env-variables": Array [
-        "connect-atlas-cli",
-      ],
-      "atlas-cli-quickstart": Array [],
-      "atlas-cli-save-connection-settings": Array [
-        "connect-atlas-cli",
-      ],
-      "cluster-config-file": Array [
-        "reference",
-      ],
-      "connect-atlas-cli": Array [],
-      "install-atlas-cli": Array [],
-      "migrate-to-atlas-cli": Array [
-        "connect-atlas-cli",
-      ],
-      "reference": Array [],
-    },
-    "project": "atlas-cli",
-    "slugToTitle": Object {
-      "atlas-cli-changelog": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Atlas CLI Changelog",
-        },
-      ],
-      "atlas-cli-commands": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Atlas CLI Commands",
-        },
-      ],
-      "atlas-cli-env-variables": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Atlas CLI Environment Variables",
-        },
-      ],
-      "atlas-cli-quickstart": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Set Up ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 0,
-                },
-              },
-              "type": "text",
-              "value": "Atlas",
-            },
-          ],
-          "name": "service",
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "substitution_reference",
-        },
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": " with ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "atlas quickstart",
-            },
-          ],
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "literal",
-        },
-      ],
-      "atlas-cli-save-connection-settings": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Save Connection Settings",
-        },
-      ],
-      "cluster-config-file": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Cluster Configuration File",
-        },
-      ],
-      "connect-atlas-cli": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Connect from the Atlas CLI",
-        },
-      ],
-      "index": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 6,
-            },
-          },
-          "type": "text",
-          "value": "Atlas CLI",
-        },
-      ],
-      "install-atlas-cli": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Install or Update the Atlas CLI",
-        },
-      ],
-      "migrate-to-atlas-cli": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 4,
-            },
-          },
-          "type": "text",
-          "value": "Migrate to the Atlas CLI",
-        },
-      ],
-      "reference": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 3,
-            },
-          },
-          "type": "text",
-          "value": "Reference",
-        },
-      ],
-    },
-    "static_files": Object {},
-    "title": "Atlas Command Line Interface",
-    "toctree": Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "options": Object {
-            "drawer": true,
-          },
-          "slug": "/",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 0,
-                },
-              },
-              "type": "text",
-              "value": "Overview",
-            },
-          ],
-        },
-        Object {
-          "children": Array [],
-          "options": Object {
-            "drawer": false,
-          },
-          "slug": "install-atlas-cli",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "Install or Update the Atlas CLI",
-            },
-          ],
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "options": Object {
-                "drawer": true,
-              },
-              "slug": "atlas-cli-save-connection-settings",
-              "title": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Save Connection Settings",
-                },
-              ],
-            },
-            Object {
-              "children": Array [],
-              "options": Object {
-                "drawer": false,
-              },
-              "slug": "atlas-cli-env-variables",
-              "title": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Atlas CLI Environment Variables",
-                },
-              ],
-            },
-            Object {
-              "children": Array [],
-              "options": Object {
-                "drawer": false,
-              },
-              "slug": "migrate-to-atlas-cli",
-              "title": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Migrate to the Atlas CLI",
-                },
-              ],
-            },
-          ],
-          "options": Object {
-            "drawer": false,
-          },
-          "slug": "connect-atlas-cli",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "Connect from the Atlas CLI",
-            },
-          ],
-        },
-        Object {
-          "children": Array [],
-          "options": Object {
-            "drawer": false,
-          },
-          "slug": "atlas-cli-quickstart",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "Set Up ",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 0,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Atlas",
-                },
-              ],
-              "name": "service",
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "substitution_reference",
-            },
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": " with ",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "atlas quickstart",
-                },
-              ],
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "literal",
-            },
-          ],
-        },
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "options": Object {
-                "drawer": true,
-              },
-              "slug": "cluster-config-file",
-              "title": Array [
-                Object {
-                  "position": Object {
-                    "start": Object {
-                      "line": 4,
-                    },
-                  },
-                  "type": "text",
-                  "value": "Cluster Configuration File",
-                },
-              ],
-            },
-          ],
-          "options": Object {
-            "drawer": true,
-          },
-          "slug": "reference",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 3,
-                },
-              },
-              "type": "text",
-              "value": "Reference",
-            },
-          ],
-        },
-        Object {
-          "children": Array [],
-          "options": Object {
-            "drawer": false,
-          },
-          "slug": "atlas-cli-changelog",
-          "title": Array [
-            Object {
-              "position": Object {
-                "start": Object {
-                  "line": 4,
-                },
-              },
-              "type": "text",
-              "value": "Atlas CLI Changelog",
-            },
-          ],
-        },
-      ],
-      "slug": "/",
-      "title": Array [
-        Object {
-          "position": Object {
-            "start": Object {
-              "line": 0,
-            },
-          },
-          "type": "text",
-          "value": "Atlas Command Line Interface",
-        },
-      ],
-    },
-    "toctreeOrder": Array [
-      "/",
-      "/",
-      "install-atlas-cli",
-      "connect-atlas-cli",
-      "atlas-cli-save-connection-settings",
-      "atlas-cli-env-variables",
-      "migrate-to-atlas-cli",
       "atlas-cli-quickstart",
       "reference",
       "cluster-config-file",

--- a/modules/persistence/tests/metadata/associated_products.test.ts
+++ b/modules/persistence/tests/metadata/associated_products.test.ts
@@ -78,7 +78,7 @@ describe('associated_products module', () => {
 
     test('getAssociatedProducts returns an aggregation cursor for metadata, grouped by most recent build_id', async () => {
       const cursor = await _getAssociatedProducts(umbrellaMetadata);
-      await cursor.forEach((doc) => {
+      await cursor.sort({ '_id.branch': -1 }).forEach((doc) => {
         expect(doc).toMatchSnapshot();
       });
     });

--- a/modules/persistence/tests/metadata/associated_products.test.ts
+++ b/modules/persistence/tests/metadata/associated_products.test.ts
@@ -34,13 +34,13 @@ describe('associated_products module', () => {
     // or update jest-mongodb-config.js
     connection = await MongoClient.connect(process.env.MONGO_URL || 'test');
     mockDb = await connection.db();
+    await mockDb.collection('repos_branches').deleteMany({});
+    await mockDb.collection('metadata').deleteMany({});
     await mockDb.collection('repos_branches').insertMany(repoBranches);
     await mockDb.collection('metadata').insertMany(metadata);
   });
 
   afterAll(async () => {
-    await mockDb.collection('repos_branches').deleteMany({});
-    await mockDb.collection('metadata').deleteMany({});
     await connection.close();
   });
 

--- a/modules/persistence/tests/metadata/metadata.test.ts
+++ b/modules/persistence/tests/metadata/metadata.test.ts
@@ -53,13 +53,13 @@ describe('metadata module', () => {
     // or update jest-mongodb-config.js
     connection = await MongoClient.connect(process.env.MONGO_URL || 'test');
     mockDb = connection.db();
+    await mockDb.collection('repos_branches').deleteMany({});
+    await mockDb.collection('metadata').deleteMany({});
     await mockDb.collection('repos_branches').insertMany(convertToBuildId(repoBranches));
     await mockDb.collection('metadata').insertMany(convertToBuildId(metadata));
   });
 
   afterAll(async () => {
-    await mockDb.collection('repos_branches').deleteMany({});
-    await mockDb.collection('metadata').deleteMany({});
     await connection.close();
   });
 

--- a/modules/persistence/tests/services/connector.test.ts
+++ b/modules/persistence/tests/services/connector.test.ts
@@ -15,7 +15,7 @@ const mockClose = jest.fn();
 jest.mock('mongodb', () => ({
   MongoClient: class MongoClient {
     constructor() {
-      console.log('constructor');
+      // console.log('constructor');
     }
     connect() {
       return mockConnect();


### PR DESCRIPTION
I was running into instances where the snapshots were coming in mixed order. The test change below in associated_products.test.ts ensures same order each time, and thus the snapshot change.

Also, was running into errors for `DuplicateKey` indicating test data was being inserted multiple times. To prevent this, ordered the `clear collection` logic before `populate collection` logic in each test suite.