### PR TITLE
DOP-3659: Adjust OpenAPI build logs

### DIFF
--- a/modules/oas-page-builder/src/services/pageBuilder.ts
+++ b/modules/oas-page-builder/src/services/pageBuilder.ts
@@ -81,14 +81,17 @@ const getAtlasSpecUrl = async ({ apiKeyword, apiVersion, resourceVersion }: Atla
     // hash in our database.
     await fetchTextData(oasFileURL, `Error fetching data from ${oasFileURL}`);
   } catch (e) {
-    console.error(e);
+    const unsuccessfulOasFileURL = oasFileURL;
     successfulGitHash = false;
 
     const res = await findLastSavedVersionData(apiKeyword);
     if (res) {
       ensureSavedVersionDataMatches(res.versions, apiVersion, resourceVersion);
       oasFileURL = `${OAS_FILE_SERVER}${res.gitHash}${versionExtension}.json`;
-      console.log(`Using ${oasFileURL}`);
+      console.log(`Error occurred fetching from newest OAS spec at ${unsuccessfulOasFileURL}.\n
+      This error is a rare but expected result of upload timing between gitHashes and specs.\n
+      If you see this error multiple times, let the DOP team know!\n\n
+      Using last successfully fetched OAS spec at ${oasFileURL}!`);
     } else {
       throw new Error(`Could not find a saved hash for API: ${apiKeyword}`);
     }


### PR DESCRIPTION
### Ticket

DOP-3659

### Notes

During docs site builds, there are not uncommon times when a new gitHash for a new OpenAPI spec has been released however the spec itself (referenced through the gitHash) is not yet fully available. 

In these instances, our build logs correctly show us the error and the eventual successful build using a previous spec. However the logs show this in a confusing order and a large error log is worrying for the docs writers. Although the builds occur correctly, this logging should be more clear as to the fact that all is well.

Example of old confusing log: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=643d73c15f7a7fd95617d611