### PR TITLE
DOP-3633: Use bulkWrites for asset upsertion

### DIFF
--- a/modules/persistence/src/services/assets/index.ts
+++ b/modules/persistence/src/services/assets/index.ts
@@ -1,5 +1,5 @@
 import AdmZip from 'adm-zip';
-import { upsert } from '../connector';
+import { bulkUpsert } from '../connector';
 
 const COLLECTION_NAME = 'assets';
 
@@ -14,8 +14,8 @@ const assetsFromZip = (zip: AdmZip) => {
 
 export const upsertAssets = async (zip: AdmZip) => {
   try {
-    const assets = await assetsFromZip(zip);
-    return Promise.all(assets.map((asset) => upsert(asset, COLLECTION_NAME, asset._id)));
+    const assets = assetsFromZip(zip);
+    return bulkUpsert(assets, COLLECTION_NAME);
   } catch (error) {
     console.error(`Error at upsertion time for ${COLLECTION_NAME}: ${error}`);
     throw error;

--- a/modules/persistence/src/services/metadata/repos_branches/index.ts
+++ b/modules/persistence/src/services/metadata/repos_branches/index.ts
@@ -1,4 +1,4 @@
-import { pool, db } from '../../connector';
+import { pool } from '../../connector';
 import { Metadata } from '..';
 import { project } from '../ToC';
 import { WithId } from 'mongodb';

--- a/modules/persistence/tests/services/connector.test.ts
+++ b/modules/persistence/tests/services/connector.test.ts
@@ -1,11 +1,11 @@
 import { ObjectID } from 'bson';
-import { db, insert, upsert } from '../../src/services/connector';
+import { bulkUpsert, db, insert } from '../../src/services/connector';
 
 const mockConnect = jest.fn();
 const mockDb = jest.fn();
 const mockCollection = jest.fn();
 const mockInsertMany = jest.fn();
-const mockUpdateOne = jest.fn();
+const mockBulkWrite = jest.fn();
 const mockClose = jest.fn();
 
 // below is a "jest mock" of a mongodb client
@@ -31,8 +31,8 @@ jest.mock('mongodb', () => ({
     async insertMany() {
       return mockInsertMany();
     }
-    async updateOne(...args) {
-      return mockUpdateOne(...args);
+    async bulkWrite(...args) {
+      return mockBulkWrite(...args);
     }
     close() {
       mockClose();
@@ -118,20 +118,28 @@ describe('Connector module', () => {
     });
   });
 
-  describe('upsert', () => {
-    const payload = { name: 'upsert-doc' };
+  describe('bulkUpsert', () => {
+    const payload = { _id: 'test-id', name: 'upsert-doc' };
     const collection = 'metadata';
-    const id = 'test-id';
+
     test('it calls on collection to update one with upsert option true', async () => {
-      await upsert(payload, collection, id);
+      await bulkUpsert([payload], collection);
       expect(mockCollection).toBeCalledWith(collection);
-      expect(mockUpdateOne).toBeCalledWith({ _id: 'test-id' }, { $set: { name: 'upsert-doc' } }, { upsert: true });
+      expect(mockBulkWrite).toBeCalledWith([
+        {
+          updateOne: {
+            filter: { _id: payload._id },
+            update: { $set: payload },
+            upsert: true,
+          },
+        },
+      ]);
     });
 
     test('it throws error on updateone error', async () => {
-      mockUpdateOne.mockRejectedValueOnce(new Error('test error') as never);
+      mockBulkWrite.mockRejectedValueOnce(new Error('test error') as never);
       try {
-        await upsert(payload, collection, id);
+        await bulkUpsert([payload], collection);
       } catch (e) {
         expect(e.message).toEqual('test error');
       }


### PR DESCRIPTION
### Ticket

DOP-3633

### Notes

* Replaces `upsert` function to be `bulkUpsert`. Core logic upserts entire document object by ID, similar to previous `upsert` logic. Biggest difference is that `bulkWrite` is utilized instead of individual `updateOne` operations.
* Observations from local runs that might be interesting to see in production: 
   * Connection count per build seems to be reduced with this change (observed from [cluster monitoring](https://cloud.mongodb.com/v2/5bad1d3d96e82129f16c5df3#/host/replicaSet/5d40b1bccf09a2026cbad969) based on timing with local builds). From console logs, I noticed that there'd be multiple attempts for the db client to connect with the previous iteration (probably through race conditions from promises).
   * Bulk write implementation seems to save about 30 seconds for the server manual locally, but could be dependent on machine.