### PR TITLE
Api version meta

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -86,5 +86,5 @@ endif
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
-	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, SITE_URL = ${SITE_URL}"
+	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, Project/User/Branch = ${PROJECT}/${USER}/${BRANCH_NAME}"
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${SITE_URL}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -81,5 +81,12 @@ endif
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
+	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, URL = ${URL}, PROJECT/USER/BRANCHNAME = /${PROJECT} + /${USER} + /${BRANCH_NAME}"
+	ifeq ($(MUT_PREFIX), "")
+		echo "Mut is empty"
+	ifeq ($(PROJECT), "cloud-docs")
+		echo "Project is equal!!!"
+	ifeq ($(PROJECT), "")
+		echo "Project is equal!!!"
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
 

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -82,11 +82,8 @@ endif
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, URL = ${URL}, PROJECT/USER/BRANCHNAME = /${PROJECT} + /${USER} + /${BRANCH_NAME}"
-	ifeq ($(MUT_PREFIX), "")
-		echo "Mut is empty"
-	ifeq ($(PROJECT), "cloud-docs")
+	ifeq ($(PROJECT),cloud-docs)
 		echo "Project is equal!!!"
-	ifeq ($(PROJECT), "")
-		echo "Project is equal!!!"
+	endif
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
 

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -77,11 +77,13 @@ next-gen-stage: ## Host online for review
 	fi
 endif
 
+# Set --site-url for oas-module build command based on availability of MUT_PREFIX
 ifeq ($(MUT_PREFIX),)
 SITE_URL=${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
 else
 SITE_URL=${URL}/${MUT_PREFIX}
 endif
+
 # Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -82,8 +82,4 @@ endif
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, URL = ${URL}, PROJECT/USER/BRANCHNAME = /${PROJECT} + /${USER} + /${BRANCH_NAME}"
-	ifeq ($(PROJECT),cloud-docs)
-		echo "Project is equal!!!"
-	endif
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
-

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -82,4 +82,9 @@ endif
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
 	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, URL = ${URL}, PROJECT/USER/BRANCHNAME = /${PROJECT} + /${USER} + /${BRANCH_NAME}"
+	ifeq ($(MUT_PREFIX),)
+		echo "We have an empty Mut prefix"
+	else
+		echo "Mut prefix has value"
+	endif
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -88,5 +88,5 @@ endif
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
-	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, Project/User/Branch = ${PROJECT}/${USER}/${BRANCH_NAME}"
+	@echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, Project/User/Branch = ${PROJECT}/${USER}/${BRANCH_NAME}"
 	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${SITE_URL}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -81,5 +81,5 @@ endif
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
-	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${MUT_PREFIX}
+	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
 

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -77,14 +77,14 @@ next-gen-stage: ## Host online for review
 	fi
 endif
 
+ifeq ($(MUT_PREFIX),)
+SITE_URL=${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
+else
+SITE_URL=${URL}/${MUT_PREFIX}
+endif
 # Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57
 # Production: https://github.com/mongodb/docs-worker-pool/blob/1a482242fa6f1463abb059884cddb2c56ba9fad9/src/job/productionJobHandler.ts#L68
 oas-page-build:
-	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, URL = ${URL}, PROJECT/USER/BRANCHNAME = /${PROJECT} + /${USER} + /${BRANCH_NAME}"
-	ifeq ($(MUT_PREFIX),)
-		echo "We have an empty Mut prefix"
-	else
-		echo "Mut prefix has value"
-	endif
-	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
+	echo "oas page build - MUT_PREFIX = ${MUT_PREFIX}, SITE_URL = ${SITE_URL}"
+	node ${OAS_MODULE_PATH} --bundle ${BUNDLE_PATH} --output ${REPO_DIR}/public --redoc ${REDOC_PATH} --repo ${REPO_DIR} --site-url ${SITE_URL}


### PR DESCRIPTION
Companion PR to [3710 PR](https://github.com/mongodb/docs-worker-pool/pull/822).

This utilizes the data passed through to replace MUT_PREFIX with correct staging link when MUT_PREFIX is not available.

In writers staging, this was unavailable at this point in the build. 

We have recreated the correct path which is as follows: Project/User/GitBranchName