### PR TITLE
DOP-3754: skip bulk upsert if operations empty

### DIFF
--- a/modules/persistence/src/services/connector/index.ts
+++ b/modules/persistence/src/services/connector/index.ts
@@ -58,6 +58,9 @@ export const insert = async (docs: any[], collection: string, buildId: ObjectId)
 export const bulkWrite = async (operations: mongodb.AnyBulkWriteOperation[], collection: string) => {
   const dbSession = await db();
   try {
+    if (!operations || !operations.length) {
+      return;
+    }
     return dbSession.collection(collection).bulkWrite(operations, { ordered: false });
   } catch (error) {
     console.error(`Error at bulk write time for ${collection}: ${error}`);

--- a/modules/persistence/tests/services/connector.test.ts
+++ b/modules/persistence/tests/services/connector.test.ts
@@ -147,5 +147,11 @@ describe('Connector module', () => {
         expect(e.message).toEqual('test error');
       }
     });
+
+    test('it skips bulkwrite if operations are empty', async () => {
+      mockBulkWrite.mockReset();
+      await bulkUpsertAll([], collection);
+      expect(mockBulkWrite).toBeCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
**GOALS**:
- skip `mongodb.bulkWrite` operations if list of operations is empty
- prevents failure of persistence module as in [example build log](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=647a37d5d7f82ac72f3885ee)