### PR TITLE
[fix] Add docs-k8s-operator to exclusion array

### DIFF
--- a/src/job/jobManager.ts
+++ b/src/job/jobManager.ts
@@ -116,7 +116,7 @@ export class JobManager {
     try {
       this._jobHandler = null;
       if (job?.payload) {
-        const excludeRepoFromBenchmarks = ['mms-docs','docs-k8s-operator'].includes(job.payload.repoName);
+        const excludeRepoFromBenchmarks = ['mms-docs', 'docs-k8s-operator'].includes(job.payload.repoName);
         // Can easily rollback with commenting out this flag.
         job.useWithBenchmark = !excludeRepoFromBenchmarks;
         await this.createHandlerAndExecute(job);

--- a/src/job/jobManager.ts
+++ b/src/job/jobManager.ts
@@ -116,7 +116,7 @@ export class JobManager {
     try {
       this._jobHandler = null;
       if (job?.payload) {
-        const excludeRepoFromBenchmarks = ['mms-docs'].includes(job.payload.repoName);
+        const excludeRepoFromBenchmarks = ['mms-docs','docs-k8s-operator'].includes(job.payload.repoName);
         // Can easily rollback with commenting out this flag.
         job.useWithBenchmark = !excludeRepoFromBenchmarks;
         await this.createHandlerAndExecute(job);


### PR DESCRIPTION
Noticed an issue with docs-k8s while trying to investigate a separate issue involving 200 responses but no slack message.

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=648b398f67a273b816827da1

^^ Example job log of failure for docs-k8s-operator.

Performing mitigation in the same vein as mms-docs.