### PR TITLE
DOP-3665: Remove private field from payload

### DIFF
--- a/api/controllers/v1/github.ts
+++ b/api/controllers/v1/github.ts
@@ -49,7 +49,6 @@ async function prepGithubPushPayload(githubEvent: any, branchRepository: BranchR
       repoName: githubEvent.repository.name,
       branchName: githubEvent.ref.split('/')[2],
       isFork: githubEvent.repository.fork,
-      private: githubEvent.repository.private,
       isXlarge: true,
       repoOwner: githubEvent.repository.owner.login,
       url: githubEvent.repository.clone_url,

--- a/api/controllers/v1/github.ts
+++ b/api/controllers/v1/github.ts
@@ -68,7 +68,7 @@ export const TriggerBuild = async (event: any = {}, context: any = {}): Promise<
   const consoleLogger = new ConsoleLogger();
   const jobRepository = new JobRepository(db, c, consoleLogger);
   const branchRepository = new BranchRepository(db, c, consoleLogger);
-  const sig = event.headers['X-Hub-Signature-256'];
+
   if (!validateJsonWebhook(event, c.get<string>('githubSecret'))) {
     const errMsg = "X-Hub-Signature incorrect. Github webhook token doesn't match";
     return {

--- a/api/controllers/v1/slack.ts
+++ b/api/controllers/v1/slack.ts
@@ -244,7 +244,6 @@ function createPayload(
     aliased,
     urlSlug,
     isFork: true,
-    private: repoOwner === '10gen',
     isXlarge: true,
     repoOwner,
     url: 'https://github.com/' + repoOwner + '/' + repoName,

--- a/api/controllers/v2/github.ts
+++ b/api/controllers/v2/github.ts
@@ -54,7 +54,6 @@ async function prepGithubPushPayload(
       repoName: githubEvent.repository.name,
       branchName: githubEvent.ref.split('/')[2],
       isFork: githubEvent.repository.fork,
-      private: githubEvent.repository.private,
       repoOwner: githubEvent.repository.owner.login,
       url: githubEvent.repository.clone_url,
       newHead: githubEvent.after,

--- a/api/controllers/v2/slack.ts
+++ b/api/controllers/v2/slack.ts
@@ -261,7 +261,6 @@ function createPayload(
     aliased,
     urlSlug,
     isFork: true,
-    private: repoOwner === '10gen',
     repoOwner,
     url: 'https://github.com/' + repoOwner + '/' + repoName,
     newHead,

--- a/src/entities/job.ts
+++ b/src/entities/job.ts
@@ -24,7 +24,6 @@ export type Payload = {
   repoName: string;
   branchName: string;
   isFork: boolean;
-  private: boolean;
   isXlarge: boolean | null | undefined;
   repoOwner: string;
   url: string;

--- a/tests/data/fullDoc.ts
+++ b/tests/data/fullDoc.ts
@@ -35,7 +35,6 @@ export default {
     aliased: true,
     urlSlug: 'upcoming',
     isFork: true,
-    private: false,
     isXlarge: true,
     repoOwner: 'mongodb',
     url: 'https://github.com/mongodb/docs-java',

--- a/tests/data/fullDocWrongUrl.ts
+++ b/tests/data/fullDocWrongUrl.ts
@@ -35,7 +35,6 @@ export default {
     aliased: true,
     urlSlug: 'upcoming',
     isFork: true,
-    private: false,
     isXlarge: true,
     repoOwner: 'mongodb',
     url: 'https://github.com/mongodb/docs-java',


### PR DESCRIPTION
### Ticket

DOP-3665

### Notes

* Removes `private` field from job payload object. I couldn't find anywhere that actually used this field.
* Leaving some of the GH actions warnings as-is for now as the issues are pre-existing and aren't necessarily related to the `private` field. (I also wanted to avoid breaking anything that didn't need to change)