### PR TITLE
Add explicit client closure to V1 Lambdas

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - "master"
       - "integration"
+      - "close-lambda-mdb-clients"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -23,12 +23,14 @@ export const TriggerLocalBuild = async (event: any = {}, context: any = {}): Pro
     consoleLogger.info(body.jobId, 'enqueuing Job');
     await sqs.sendMessage(new JobQueueMessage(body.jobId, JobStatus.inQueue), c.get('jobUpdatesQueueUrl'), 0);
     consoleLogger.info(body.jobId, 'Job Queued Job');
+    client.close();
     return {
       statusCode: 202,
       headers: { 'Content-Type': 'text/plain' },
       body: body.jobId,
     };
   } catch (err) {
+    client.close();
     consoleLogger.error('TriggerLocalBuild', err);
     return {
       statusCode: 500,
@@ -106,7 +108,9 @@ export const FailStuckJobs = async () => {
   try {
     const hours = 8;
     await jobRepository.failStuckJobs(hours);
+    client.close();
   } catch (err) {
+    client.close();
     consoleLogger.error('FailStuckJobs', err);
   }
 };
@@ -124,7 +128,9 @@ async function saveTaskId(jobId: string, taskExecutionRes: any, consoleLogger: C
     // Only interested in the actual task ID since the whole ARN might have sensitive information
     const taskId = taskArn.split('/').pop();
     await jobRepository.addTaskIdToJob(jobId, taskId);
-  } catch (err) {
+    client.close();
+  } catch (err) {   
+    client.close();
     consoleLogger.error('saveTaskId', err);
   }
 }
@@ -181,6 +187,7 @@ async function NotifyBuildSummary(jobId: string): Promise<any> {
     ),
     entitlement['slack_user_id']
   );
+  client.close();
   return {
     statusCode: 200,
   };
@@ -284,6 +291,7 @@ async function NotifyBuildProgress(jobId: string): Promise<any> {
     ),
     entitlement['slack_user_id']
   );
+  client.close();
   return {
     statusCode: 200,
   };
@@ -333,4 +341,5 @@ async function SubmitArchiveJob(jobId: string) {
     repo.prefix[environment]
   );
   consoleLogger.info('submit archive job', JSON.stringify({ jobId: jobId, batchJobId: response.jobId }));
+  client.close();
 }

--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -129,7 +129,7 @@ async function saveTaskId(jobId: string, taskExecutionRes: any, consoleLogger: C
     const taskId = taskArn.split('/').pop();
     await jobRepository.addTaskIdToJob(jobId, taskId);
     client.close();
-  } catch (err) {   
+  } catch (err) {
     client.close();
     consoleLogger.error('saveTaskId', err);
   }

--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -23,14 +23,14 @@ export const TriggerLocalBuild = async (event: any = {}, context: any = {}): Pro
     consoleLogger.info(body.jobId, 'enqueuing Job');
     await sqs.sendMessage(new JobQueueMessage(body.jobId, JobStatus.inQueue), c.get('jobUpdatesQueueUrl'), 0);
     consoleLogger.info(body.jobId, 'Job Queued Job');
-    client.close();
+    await client.close();
     return {
       statusCode: 202,
       headers: { 'Content-Type': 'text/plain' },
       body: body.jobId,
     };
   } catch (err) {
-    client.close();
+    await client.close();
     consoleLogger.error('TriggerLocalBuild', err);
     return {
       statusCode: 500,
@@ -108,9 +108,9 @@ export const FailStuckJobs = async () => {
   try {
     const hours = 8;
     await jobRepository.failStuckJobs(hours);
-    client.close();
+    await client.close();
   } catch (err) {
-    client.close();
+    await client.close();
     consoleLogger.error('FailStuckJobs', err);
   }
 };
@@ -128,9 +128,9 @@ async function saveTaskId(jobId: string, taskExecutionRes: any, consoleLogger: C
     // Only interested in the actual task ID since the whole ARN might have sensitive information
     const taskId = taskArn.split('/').pop();
     await jobRepository.addTaskIdToJob(jobId, taskId);
-    client.close();
+    await client.close();
   } catch (err) {
-    client.close();
+    await client.close();
     consoleLogger.error('saveTaskId', err);
   }
 }
@@ -187,7 +187,7 @@ async function NotifyBuildSummary(jobId: string): Promise<any> {
     ),
     entitlement['slack_user_id']
   );
-  client.close();
+  await client.close();
   return {
     statusCode: 200,
   };
@@ -291,7 +291,7 @@ async function NotifyBuildProgress(jobId: string): Promise<any> {
     ),
     entitlement['slack_user_id']
   );
-  client.close();
+  await client.close();
   return {
     statusCode: 200,
   };
@@ -341,5 +341,5 @@ async function SubmitArchiveJob(jobId: string) {
     repo.prefix[environment]
   );
   consoleLogger.info('submit archive job', JSON.stringify({ jobId: jobId, batchJobId: response.jobId }));
-  client.close();
+  await client.close();
 }

--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -19,24 +19,26 @@ export const TriggerLocalBuild = async (event: any = {}, context: any = {}): Pro
   const consoleLogger = new ConsoleLogger();
   const sqs = new SQSConnector(consoleLogger, c);
   const body = JSON.parse(event.body);
+  let resp = {};
   try {
     consoleLogger.info(body.jobId, 'enqueuing Job');
     await sqs.sendMessage(new JobQueueMessage(body.jobId, JobStatus.inQueue), c.get('jobUpdatesQueueUrl'), 0);
     consoleLogger.info(body.jobId, 'Job Queued Job');
-    await client.close();
-    return {
+    resp = {
       statusCode: 202,
       headers: { 'Content-Type': 'text/plain' },
       body: body.jobId,
     };
   } catch (err) {
-    await client.close();
     consoleLogger.error('TriggerLocalBuild', err);
-    return {
+    resp = {
       statusCode: 500,
       headers: { 'Content-Type': 'text/plain' },
       body: err,
     };
+  } finally {
+    await client.close();
+    return resp;
   }
 };
 
@@ -108,10 +110,10 @@ export const FailStuckJobs = async () => {
   try {
     const hours = 8;
     await jobRepository.failStuckJobs(hours);
-    await client.close();
   } catch (err) {
-    await client.close();
     consoleLogger.error('FailStuckJobs', err);
+  } finally {
+    await client.close();
   }
 };
 
@@ -128,10 +130,10 @@ async function saveTaskId(jobId: string, taskExecutionRes: any, consoleLogger: C
     // Only interested in the actual task ID since the whole ARN might have sensitive information
     const taskId = taskArn.split('/').pop();
     await jobRepository.addTaskIdToJob(jobId, taskId);
-    await client.close();
   } catch (err) {
-    await client.close();
     consoleLogger.error('saveTaskId', err);
+  } finally {
+    await client.close();
   }
 }
 


### PR DESCRIPTION
Adds explicit `client.close()` statements to the jobHandler to mitigate potential thread overuse from dangling connections.

Successful deploy log here:

https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=6494b9aa0379b4804917fa5e