### PR TITLE
[DOP-3755] Fix potential null access terminal error case

### DIFF
--- a/modules/persistence/src/services/metadata/associated_products/index.ts
+++ b/modules/persistence/src/services/metadata/associated_products/index.ts
@@ -117,7 +117,7 @@ const shapeToCsCursor = async (
     if (repoBranchesEntry) {
       const { url, prefix } = prefixFromEnvironment(branches);
       const { urlSlug, urlAliases = [], gitBranchName, publishOriginalBranchName } = repoBranchesEntry;
-      const alias = urlSlug || urlAliases[0] || (publishOriginalBranchName && gitBranchName);
+      const alias = urlSlug || urlAliases?.[0] || (publishOriginalBranchName && gitBranchName);
       tocInsertions[project][branch] = {
         original: copyToCTree(metadata.toctree),
         urlified: copyToCTree(metadata.toctree, prefix, url, alias),


### PR DESCRIPTION
Fixes a case where associating properties with null `urlAliases` causes a terminal error within ToC merging.

Apparently default assign of the `[]` in the destructure on the line prior to my change (`119`) does not overwrite explicit `null`, only undefined 🤔 

Without handling, error manifests as:
```
Error at time of merging associated ToC entries: TypeError: Cannot read property '0' of null
Error during umbrella metadata update: TypeError: Cannot read property '0' of null
Persistence Module encountered a terminal error: TypeError: Cannot read property '0' of null
/Users/cassidy.schaufele/Documents/GitHub/docs-worker-pool/modules/persistence/dist/src/services/metadata/associated_products/index.js:75
            const alias = urlSlug || urlAliases[0] || (publishOriginalBranchName && gitBranchName);
```

See https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=64991b7f7112a4f68dbcd55a for an example when deployed to `preprd` with configuration of Datalake and Charts associated with Cloud Docs.