### PR TITLE
DOP-3832: remove dependency on docs-assets

### DIFF
--- a/makefiles/Makefile.docs-ecosystem
+++ b/makefiles/Makefile.docs-ecosystem
@@ -20,13 +20,7 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-assets: ## pulls assets from the docs-assets
-	rm -rf source/figures docs-assets
-	mkdir source/figures
-	git clone http://github.com/mongodb/docs-assets.git
-	cd docs-assets; git checkout ecosystem; cp -a * ../source/figures
-
-get-build-dependencies: assets
+get-build-dependencies:
 	curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-ecosystem.yaml > ${REPO_DIR}/published-branches.yaml
 
 


### PR DESCRIPTION
Merge in tandem with the docs-ecosystem PR that adds the images (https://github.com/mongodb/docs-ecosystem/pull/897)