### PR TITLE
DOP-3863: shared.mk passes githubUser flag to persistence module

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -59,6 +59,7 @@ endif
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
+	@echo "persistence build - GH_USER = ${GH_USER}, GH_USER_ARG = ${GH_USER_ARG}"
 	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -49,10 +49,17 @@ next-gen-parse:
 		fi \
 	fi
 
+# Set Github user to docs-builder-bot if empty
+ifeq ($(GH_USER),)
+GH_USER_ARG=docs-builder-bot
+else
+GH_USER_ARG=${GH_USER}
+endif
+
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER}
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -59,7 +59,6 @@ endif
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	@echo "persistence build - GH_USER = ${GH_USER}, GH_USER_ARG = ${GH_USER_ARG}"
 	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -52,7 +52,7 @@ next-gen-parse:
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;


### PR DESCRIPTION
### Ticket

DOP-3863

### Notes

This ensures the meta branch's shared makefile pipes through the correct variable to the Persistence module's run command as the githubUser argument.

Two examples:
- [with a github user provided](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=64bade6587b3b36046d78b3b)
- [with no github user provided](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=64baddf0c8dcb629b89d4bc2) (defaults to docs-builder-bot as seen in logs)

