### PR TITLE
DOP-3837: remove base branch==master assumption

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -23,9 +23,9 @@ get-project-name:
 	@echo ${PROJECT};
 
 
-ifndef CUSTOM_NEXT_GEN_DEPLOY
+ifndef CUSTOM_NEXT_GEN_DEPLOY # def'd for docs-mongodb-internal* and docs-404 only
 next-gen-deploy:
-	if [ -f config/redirects -a "${GIT_BRANCH}" = master ]; then mut-redirects config/redirects -o public/.htaccess; fi
+	if [ -f config/redirects ] && [ "${GIT_BRANCH}" = master -o "${GIT_BRANCH}" = main ]; then mut-redirects config/redirects -o public/.htaccess; fi
 	yes | mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --deploy --deployed-url-prefix=${URL} --json --all-subdirectories ${ARGS};
 	@echo "Hosted at ${URL}/${MUT_PREFIX}";
 endif


### PR DESCRIPTION
This appears to be the only place we still assume the base branch is `master`! We'll very happily let people stage branches called `master` now (e.g. https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bfc8c287b3b36046c9bed3 builds a cloud-docs branch named `master`, which we used to -- some many moons ago -- just auto-fail) and there is no other docs-worker-pool code I could find that cared.

Custom deploys are only defined for docs-mongodb-internal, which has no deploy support being internal-only, so the other Makefiles didn't need touching.