### PR TITLE
Add updated time when marking data for deletion

### DIFF
--- a/src/repositories/updatedDocsRepository.ts
+++ b/src/repositories/updatedDocsRepository.ts
@@ -25,6 +25,7 @@ export class UpdatedDocsRepository extends BaseRepository {
     const update = {
       $set: {
         deleted: true,
+        updated_at: new Date(),
       },
     };
 


### PR DESCRIPTION
### Notes

* Updates the `updated_at` field when marking ASTs for deletion. This is needed so that the API and source plugin can see these newly marked pages as "updated".
* The metadata document should not need this same field because the latest metadata document is returned regardless of if the timestamp has changed.