### PR TITLE
DOP-3722: meta - Persistence Module fail ends build

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -55,8 +55,12 @@ next-gen-parse: examples
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-atlas-cli
+++ b/makefiles/Makefile.docs-atlas-cli
@@ -39,8 +39,12 @@ next-gen-parse: fetch-submodule
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -50,10 +50,10 @@ next-gen-html:
 	# ignore errors "-" flag
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	if [ $$? -eq 1 ]; then \
-		echo "WE GOT A ONE FROM PERSISTENCE - landing"
+		@echo "WE GOT A ONE FROM PERSISTENCE - landing"
 		exit 1; \
 	else \
-		echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE - landing"
+		@echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE - landing"
 		exit 0; \
 	fi \
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -48,7 +48,7 @@ next-gen-html:
 	fi
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	-k node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -47,8 +47,12 @@ next-gen-html:
 		exit 0; \
 	fi
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	if [ $$? -eq 1 ]; then \
 		@echo "WE GOT A ONE FROM PERSISTENCE - landing"
 		exit 1; \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -48,7 +48,14 @@ next-gen-html:
 	fi
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-k node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		echo "WE GOT A ONE FROM PERSISTENCE - landing"
+		exit 1; \
+	else \
+		echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE - landing"
+		exit 0; \
+	fi \
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -39,8 +39,12 @@ next-gen-parse: fetch-submodule
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -43,8 +43,12 @@ next-gen-parse: examples
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal-base
+++ b/makefiles/Makefile.docs-mongodb-internal-base
@@ -42,8 +42,12 @@ next-gen-parse: examples
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongoid
+++ b/makefiles/Makefile.docs-mongoid
@@ -35,8 +35,12 @@ next-gen-parse: get-build-dependencies
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -35,8 +35,12 @@ next-gen-parse: get-build-dependencies
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -35,8 +35,12 @@ next-gen-parse: get-build-dependencies
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -105,8 +105,12 @@ next-gen-html: examples
 		fi \
 	fi
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR} && \
 	cd snooty && \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production && \

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -51,11 +51,12 @@ next-gen-parse:
 
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
-	# ignore errors "-" flag
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	if [ $$? -eq 1 ]; then \
+		echo "WE GOT A ONE FROM PERSISTENCE"
 		exit 1; \
 	else \
+		echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE"
 		exit 0; \
 	fi \
 	# build-front-end after running parse commands

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -53,6 +53,11 @@ next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -53,10 +53,10 @@ next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	if [ $$? -eq 1 ]; then \
-		echo "WE GOT A ONE FROM PERSISTENCE"
+		@echo "WE GOT A ONE FROM PERSISTENCE"
 		exit 1; \
 	else \
-		echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE"
+		@echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE"
 		exit 0; \
 	fi \
 	# build-front-end after running parse commands

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -52,7 +52,7 @@ next-gen-parse:
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-k node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -53,10 +53,8 @@ next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	if [ $$? -eq 1 ]; then \
-		@echo "WE GOT A ONE FROM PERSISTENCE"
 		exit 1; \
 	else \
-		@echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE"
 		exit 0; \
 	fi \
 	# build-front-end after running parse commands

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -52,7 +52,7 @@ next-gen-parse:
 next-gen-html:
 	# persistence module - add bundle zip to Atlas documents
 	# ignore errors "-" flag
-	-node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
+	-k node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH}
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;


### PR DESCRIPTION
### Ticket

DOP-3722

### Notes

The updated documents and metadata created by the Persistence Module have become integral to our builds moving forward. To support our continued Build Speed Enhancements project with Gatsby, we need any failure to update these documents to end the entire build. This is split into two PRs. 

This PR alters the meta branch Makefiles to not ignore errors stemming from the Persistence Module and to exit with an error status immediately.