### PR TITLE
[HOTFIX]: Add STAGE environment variable to webhooks

### DIFF
--- a/cdk-infra/lib/constructs/api/webhook-env-construct.ts
+++ b/cdk-infra/lib/constructs/api/webhook-env-construct.ts
@@ -44,6 +44,7 @@ export class WebhookEnvConstruct extends Construct {
       NODE_OPTIONS: '--enable-source-maps',
       USER_ENTITLEMENT_COL_NAME: entitlementCollection,
       DASHBOARD_URL: getDashboardUrl(env, jobCollection),
+      STAGE: env,
     };
   }
 }


### PR DESCRIPTION
This is a quick fix so that the slackbot provides the correct `Env` value in the build completion message.