### PR TITLE
DOP-3907: Update time for marking metadata doc deletion

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - "master"
       - "integration"
-      # TODO-3907: Remove after testing
-      - "DOP-3907"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - "master"
       - "integration"
+      # TODO-3907: Remove after testing
+      - "DOP-3907"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/api/handlers/github.ts
+++ b/api/handlers/github.ts
@@ -102,8 +102,8 @@ export const markBuildArtifactsForDeletion = async (event: APIGatewayEvent) => {
     const metadataRepository = new MetadataRepository(snootyDb, c, consoleLogger);
     const updateTime = new Date();
     await Promise.all([
-      updatedDocsRepository.marksAstsForDeletion(project, branch, updateTime),
-      metadataRepository.marksMetadataForDeletion(project, branch, updateTime),
+      updatedDocsRepository.markAstsForDeletion(project, branch, updateTime),
+      metadataRepository.markMetadataForDeletion(project, branch, updateTime),
     ]);
   } catch (e) {
     consoleLogger.error('MarkBuildArtifactsForDeletion', e);

--- a/api/handlers/github.ts
+++ b/api/handlers/github.ts
@@ -100,9 +100,10 @@ export const markBuildArtifactsForDeletion = async (event: APIGatewayEvent) => {
     const snootyDb = client.db(c.get('snootyDbName'));
     const updatedDocsRepository = new UpdatedDocsRepository(snootyDb, c, consoleLogger);
     const metadataRepository = new MetadataRepository(snootyDb, c, consoleLogger);
+    const updateTime = new Date();
     await Promise.all([
-      updatedDocsRepository.marksAstsForDeletion(project, branch),
-      metadataRepository.marksMetadataForDeletion(project, branch),
+      updatedDocsRepository.marksAstsForDeletion(project, branch, updateTime),
+      metadataRepository.marksMetadataForDeletion(project, branch, updateTime),
     ]);
   } catch (e) {
     consoleLogger.error('MarkBuildArtifactsForDeletion', e);

--- a/src/job/stagingJobHandler.ts
+++ b/src/job/stagingJobHandler.ts
@@ -82,9 +82,7 @@ export class StagingJobHandler extends JobHandler {
         this.currJob._id,
         `${'(GATSBY_CLOUD_PREVIEW_WEBHOOK_ENABLED)'.padEnd(15)}${featurePreviewWebhookEnabled}`
       );
-      if (featurePreviewWebhookEnabled) {
-        // TODO: current using a rudimentary logging approach, should switch to
-        // something more robust once we are closer to going live.
+      if (featurePreviewWebhookEnabled?.toLowerCase() === 'true') {
         try {
           const response = await this.previewWebhook();
           await this.logger.save(this.currJob._id, `${'(POST Webhook Status)'.padEnd(15)}${response.status}`);

--- a/src/repositories/metadataRepository.ts
+++ b/src/repositories/metadataRepository.ts
@@ -18,7 +18,7 @@ export class MetadataRepository extends BaseRepository {
    * @param branch
    * @param updateTime
    */
-  async marksMetadataForDeletion(project: string, branch: string, updateTime: Date) {
+  async markMetadataForDeletion(project: string, branch: string, updateTime: Date) {
     const query = { project, branch };
     const update = {
       $set: {

--- a/src/repositories/metadataRepository.ts
+++ b/src/repositories/metadataRepository.ts
@@ -16,12 +16,14 @@ export class MetadataRepository extends BaseRepository {
    * of the metadata should handle metadata marked for deletion accordingly.
    * @param project
    * @param branch
+   * @param updateTime
    */
-  async marksMetadataForDeletion(project: string, branch: string) {
+  async marksMetadataForDeletion(project: string, branch: string, updateTime: Date) {
     const query = { project, branch };
     const update = {
       $set: {
         deleted: true,
+        updated_at: updateTime,
       },
     };
 

--- a/src/repositories/updatedDocsRepository.ts
+++ b/src/repositories/updatedDocsRepository.ts
@@ -16,8 +16,9 @@ export class UpdatedDocsRepository extends BaseRepository {
    * handle page documents marked for deletion accordingly.
    * @param project
    * @param branch
+   * @param updateTime
    */
-  async marksAstsForDeletion(project: string, branch: string) {
+  async marksAstsForDeletion(project: string, branch: string, updateTime: Date) {
     const pageIdPrefix = `${project}/docsworker-xlarge/${branch}`;
     const query = {
       page_id: { $regex: new RegExp(`^${pageIdPrefix}/`) },
@@ -25,7 +26,7 @@ export class UpdatedDocsRepository extends BaseRepository {
     const update = {
       $set: {
         deleted: true,
-        updated_at: new Date(),
+        updated_at: updateTime,
       },
     };
 

--- a/src/repositories/updatedDocsRepository.ts
+++ b/src/repositories/updatedDocsRepository.ts
@@ -18,7 +18,7 @@ export class UpdatedDocsRepository extends BaseRepository {
    * @param branch
    * @param updateTime
    */
-  async marksAstsForDeletion(project: string, branch: string, updateTime: Date) {
+  async markAstsForDeletion(project: string, branch: string, updateTime: Date) {
     const pageIdPrefix = `${project}/docsworker-xlarge/${branch}`;
     const query = {
       page_id: { $regex: new RegExp(`^${pageIdPrefix}/`) },

--- a/tests/unit/api/github.test.ts
+++ b/tests/unit/api/github.test.ts
@@ -15,14 +15,14 @@ jest.mock('../../../src/repositories/repoBranchesRepository', () => ({
 // Mock MetadataRepository so that we can mock which data to return.
 jest.mock('../../../src/repositories/metadataRepository', () => ({
   MetadataRepository: jest.fn().mockImplementation(() => ({
-    marksMetadataForDeletion: jest.fn(),
+    markMetadataForDeletion: jest.fn(),
   })),
 }));
 
 // Mock UpdatedDocsRepository so that we can mock which data to return.
 jest.mock('../../../src/repositories/updatedDocsRepository', () => ({
   UpdatedDocsRepository: jest.fn().mockImplementation(() => ({
-    marksAstsForDeletion: jest.fn(),
+    markAstsForDeletion: jest.fn(),
   })),
 }));
 


### PR DESCRIPTION
### Ticket

DOP-3907

### Notes

* Adds new `updated_at` field to metadata documents when they are being marked for deletion. This will be leveraged by the Snooty Data API to allow it to identify that there was a change in the metadata for a project + branch without needing to perform a new parse.
* Fixes a small bug with checking the feature flag for the preview webhook. It was checking for a truthy string, which would be truthy even if the env's value was "false". Not a big deal, but this has resulted in unintentional calls to one of the Gatsby Cloud sites.