### PR TITLE
Remove extra if in docs-landing Makefile

### DIFF
--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -59,7 +59,7 @@ next-gen-html:
 		exit 1; \
 	else \
 		exit 0; \
-	fi \
+	fi
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -60,13 +60,6 @@ next-gen-html:
 	else \
 		exit 0; \
 	fi \
-	if [ $$? -eq 1 ]; then \
-		@echo "WE GOT A ONE FROM PERSISTENCE - landing"
-		exit 1; \
-	else \
-		@echo "WE GOT A ZERO or ${$$?} FROM PERSISTENCE - landing"
-		exit 0; \
-	fi \
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \


### PR DESCRIPTION
Noticed this weird error when trying to build `docs-landing` ([build log](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=queue&jobId=64cd559867dbe91010006af0)):

```
Error: Command failed: make next-gen-html GH_USER=rayangler
INFO:snooty.main:Snooty 0.14.3 starting
INFO:snooty.parser:cache: 0 hits and 8 misses
/bin/sh: 6: Syntax error: "if" unexpected
make: *** [Makefile:53: next-gen-html] Error 2
```

I was able to reproduce this issue locally using a minimal example, so I believe this change should fix it! 🤞 