### PR TITLE
Return the value of the update

### DIFF
--- a/src/repositories/jobRepository.ts
+++ b/src/repositories/jobRepository.ts
@@ -46,7 +46,7 @@ export class JobRepository extends BaseRepository {
     if (shouldNotifySqs) {
       await this.notify(objectId.toString(), c.get('jobUpdatesQueueUrl'), JobStatus.completed, 0);
     }
-    return updateResponse;
+    return updateResponse.value;
   }
 
   async insertJob(job: Omit<Job | EnhancedJob, '_id'>, url: string): Promise<string> {

--- a/tests/unit/repositories/jobRepository.test.ts
+++ b/tests/unit/repositories/jobRepository.test.ts
@@ -200,7 +200,7 @@ describe('Job Repository Tests', () => {
   }
 
   function setupForFindOneAndUpdateSuccess() {
-    dbRepoHelper.collection.findOneAndUpdate.mockReturnValueOnce(job);
+    dbRepoHelper.collection.findOneAndUpdate.mockReturnValueOnce({ value: job });
     jest.spyOn(jobRepo, 'notify').mockResolvedValueOnce(true);
     dbRepoHelper.config.get.calledWith('MONGO_TIMEOUT_S').mockReturnValueOnce(1);
   }


### PR DESCRIPTION
`findOneAndUpdate` apparently returns the original document nested in a response object. This PR hopes to fix this by returning the actual value.