### PR TITLE
Update deploy-prd-enhanced-worker.yml

### DIFF
--- a/.github/workflows/deploy-prd-enhanced-webhooks.yml
+++ b/.github/workflows/deploy-prd-enhanced-webhooks.yml
@@ -1,6 +1,5 @@
 on:
   push:
-    paths: ["api/v2/**", "cdk-infra/lib/constructs/api/**", "cdk-infra/utils"]
     tags:
       - 'v*'
 

--- a/.github/workflows/deploy-prd-enhanced-webhooks.yml
+++ b/.github/workflows/deploy-prd-enhanced-webhooks.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    paths: ["api/v2/**", "cdk-infra/lib/constructs/api/**"]
+    paths: ["api/v2/**", "cdk-infra/lib/constructs/api/**", "cdk-infra/utils"]
     tags:
       - 'v*'
 

--- a/.github/workflows/deploy-prd-enhanced-worker.yml
+++ b/.github/workflows/deploy-prd-enhanced-worker.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    paths: ["src/**", "cdk-infra/lib/constructs/worker/**"]
+    paths: ["src/**", "cdk-infra/lib/constructs/worker/**", "Dockerfile.enhanced", "cdk-infra/utils"]
     tags:
       - 'v*'
 

--- a/.github/workflows/deploy-prd-enhanced-worker.yml
+++ b/.github/workflows/deploy-prd-enhanced-worker.yml
@@ -1,6 +1,5 @@
 on:
   push:
-    paths: ["src/**", "cdk-infra/lib/constructs/worker/**", "Dockerfile.enhanced", "cdk-infra/utils"]
     tags:
       - 'v*'
 


### PR DESCRIPTION
Add additional files that trigger a build for the enhanced webhook and worker. If these directories are not included, it could cause errors such as missing environment variables. For example, if we add a secure string for the worker in `utils/ssm.ts`, that will not trigger a deploy for the worker infrastructure, leading to errors from the missing environment variable.