### PR TITLE
add ci command for webhooks and increase visibility timeout

### DIFF
--- a/.github/workflows/deploy-prd-enhanced-webhooks.yml
+++ b/.github/workflows/deploy-prd-enhanced-webhooks.yml
@@ -23,6 +23,7 @@ jobs:
           aws-region: us-east-2
       - name: Deploy Enhanced Infrastructure
         run: |
+          npm ci
           cd cdk-infra/
           npm ci
           npm run deploy:enhanced:webhooks -- -c env=prd -c customFeatureName=enhancedApp

--- a/.github/workflows/deploy-stg-enhanced-webhooks.yml
+++ b/.github/workflows/deploy-stg-enhanced-webhooks.yml
@@ -25,6 +25,7 @@ jobs:
           aws-region: us-east-2
       - name: Deploy Enhanced Infrastructure
         run: |
+          npm ci
           cd cdk-infra/
           npm ci
           npm run deploy:enhanced:webhooks -- -c env=dotcomstg -c customFeatureName=enhancedApp-dotcomstg

--- a/cdk-infra/lib/constructs/queue/queues-construct.ts
+++ b/cdk-infra/lib/constructs/queue/queues-construct.ts
@@ -1,3 +1,4 @@
+import { Duration } from 'aws-cdk-lib';
 import { IQueue, Queue } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
 
@@ -13,6 +14,7 @@ export class AutoBuilderQueuesConstruct extends Construct {
     const jobsQueueDlq = new Queue(this, 'jobsQueueDlq');
 
     const jobsQueue = new Queue(this, 'JobsQueue', {
+      visibilityTimeout: Duration.seconds(120),
       deadLetterQueue: {
         queue: jobsQueueDlq,
         maxReceiveCount,
@@ -22,6 +24,7 @@ export class AutoBuilderQueuesConstruct extends Construct {
     const jobUpdatesQueueDlq = new Queue(this, 'jobUpdatesQueueDlq');
 
     const jobUpdatesQueue = new Queue(this, 'JobUpdatesQueue', {
+      visibilityTimeout: Duration.seconds(120),
       deadLetterQueue: {
         queue: jobUpdatesQueueDlq,
         maxReceiveCount,


### PR DESCRIPTION
I increased the `visibilityTimeout` property for the queues because there was the following error occurred when attempting to deploy the staging environment:

```
auto-builder-stack-enhancedApp-dotcomstg-webhooks | 9:28:34 PM | CREATE_FAILED        | AWS::Lambda::EventSourceMapping | api/handleJobsLambda/SqsEventSource:autobuilderstackenhancedAppdotcomstgqueuesJobUpdatesQueue862D290D (apihandleJobsLambdaSqsEventSourceautobuilderstackenhancedAppdotcomstgqueuesJobUpdatesQueue862D290D35BB8AD7) Resource handler returned message: "Invalid request provided: Queue visibility timeout: 30 seconds is less than Function timeout: 120 seconds (Service: Lambda, Status Code: 400, Request ID: 14ed7a5c-9f22-4c81-948a-35ae2e028b63)" (RequestToken: cabb6d1e-271d-ac18-479d-157538643662, HandlerErrorCode: InvalidRequest)

```