### PR TITLE
DOP-3943: Mark data for deletion based on user

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - "master"
       - "integration"
-      # TODO-3943: Remove temp branch
-      - "DOP-3943"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - "master"
       - "integration"
+      # TODO-3943: Remove temp branch
+      - "DOP-3943"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/api/handlers/github.ts
+++ b/api/handlers/github.ts
@@ -87,6 +87,7 @@ export const markBuildArtifactsForDeletion = async (event: APIGatewayEvent) => {
 
   const { repository, pull_request: pullRequest } = payload;
   const branch = pullRequest.head.ref;
+  const user = pullRequest.user.login;
 
   const client = new mongodb.MongoClient(c.get('dbUrl'));
 
@@ -102,8 +103,8 @@ export const markBuildArtifactsForDeletion = async (event: APIGatewayEvent) => {
     const metadataRepository = new MetadataRepository(snootyDb, c, consoleLogger);
     const updateTime = new Date();
     await Promise.all([
-      updatedDocsRepository.markAstsForDeletion(project, branch, updateTime),
-      metadataRepository.markMetadataForDeletion(project, branch, updateTime),
+      updatedDocsRepository.markAstsForDeletion(project, branch, user, updateTime),
+      metadataRepository.markMetadataForDeletion(project, branch, user, updateTime),
     ]);
   } catch (e) {
     consoleLogger.error('MarkBuildArtifactsForDeletion', e);

--- a/src/repositories/metadataRepository.ts
+++ b/src/repositories/metadataRepository.ts
@@ -18,8 +18,8 @@ export class MetadataRepository extends BaseRepository {
    * @param branch
    * @param updateTime
    */
-  async markMetadataForDeletion(project: string, branch: string, updateTime: Date) {
-    const query = { project, branch };
+  async markMetadataForDeletion(project: string, branch: string, user: string, updateTime: Date) {
+    const query = { project, branch, github_username: user };
     const update = {
       $set: {
         deleted: true,

--- a/src/repositories/updatedDocsRepository.ts
+++ b/src/repositories/updatedDocsRepository.ts
@@ -18,10 +18,11 @@ export class UpdatedDocsRepository extends BaseRepository {
    * @param branch
    * @param updateTime
    */
-  async markAstsForDeletion(project: string, branch: string, updateTime: Date) {
+  async markAstsForDeletion(project: string, branch: string, user: string, updateTime: Date) {
     const pageIdPrefix = `${project}/docsworker-xlarge/${branch}`;
     const query = {
       page_id: { $regex: new RegExp(`^${pageIdPrefix}/`) },
+      github_username: user,
     };
     const update = {
       $set: {

--- a/tests/unit/api/github.test.ts
+++ b/tests/unit/api/github.test.ts
@@ -36,6 +36,9 @@ describe('GitHub API Tests', () => {
     const successfulPayload = {
       action: 'closed',
       pull_request: {
+        user: {
+          login: 'test-user',
+        },
         head: {
           ref: 'test-webhook',
         },


### PR DESCRIPTION
### Ticket

DOP-3943

### Notes

* Fixes a potential future bug where if 2 users have the data with the same project + branch, the deletion webhook could mark every data with that project + branch for deletion instead of only the user's fork of the data.