### PR TITLE
DOP-3801: Ensure db pools/topologies are used efficiently

### DIFF
--- a/modules/persistence/index.ts
+++ b/modules/persistence/index.ts
@@ -5,7 +5,7 @@ dotenv.config();
 import AdmZip from 'adm-zip';
 import minimist from 'minimist';
 import * as mongodb from 'mongodb';
-import { teardown as closeDBConnection } from './src/services/connector';
+import { db as snootyDb, pool as poolDb, teardown as closeDBConnection } from './src/services/connector';
 import { insertAndUpdatePages } from './src/services/pages';
 import {
   insertMetadata,
@@ -38,6 +38,9 @@ const app = async (path: string, githubUser: string) => {
     // that only one build will be used per run of this module.
     const buildId = new mongodb.ObjectId();
     const metadata = await metadataFromZip(zip, githubUser);
+    // initialize db connections to handle shared connections
+    await snootyDb();
+    await poolDb();
     await Promise.all([
       insertAndUpdatePages(buildId, zip, githubUser),
       insertMetadata(buildId, metadata),

--- a/modules/persistence/src/services/connector/pool/index.ts
+++ b/modules/persistence/src/services/connector/pool/index.ts
@@ -6,7 +6,6 @@ let dbInstance: Db;
 export const db = async (client: MongoClient) => {
   if (!dbInstance) {
     try {
-      await client.connect();
       dbInstance = client.db(process.env.DB_NAME);
     } catch (error) {
       console.error(`Error at db client connection: ${error}`);


### PR DESCRIPTION
### Ticket

DOP-3801

### Notes

The Persistence Module already had functionality implemented to cache db connections, but the asynchronous nature of the Promise.all call was not allowing time for the first connection to succeed before each function in turn needed it. This led to four connections rather than the desired one to be shared.

Both db connections needed for the module are now awaited, created, and cached before the module moves on.