### PR TITLE
DOP-3951: Separate persistence module Makefile rule

### DIFF
--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -57,13 +57,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
@@ -94,6 +87,15 @@ SITE_URL=${URL}/${PROJECT}/${USER}/${BRANCH_NAME}
 else
 SITE_URL=${URL}/${MUT_PREFIX}
 endif
+
+persistence-module:
+	# persistence module - add bundle zip to Atlas documents
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
+	if [ $$? -eq 1 ]; then \
+		exit 1; \
+	else \
+		exit 0; \
+	fi
 
 # Intended to be called by the autobuilder as a build command after frontend build, but before mut upload
 # Staging: https://github.com/mongodb/docs-worker-pool/blob/42bd36b1f52e49c646a79474c12d299f33d774cb/src/job/stagingJobHandler.ts#L57


### PR DESCRIPTION
### Ticket

DOP-3951

### Notes

* This PR splits the persistence module apart from the `next-gen-html` rule. This is an additional Makefile change needed to allow the Gatsby Cloud preview webhook to be called immediately after the persistence module is called.
* The individual Makefiles that have their own calls to `next-gen-html` have been unchanged to avoid breaking persistence module behavior immediately (since updates to repo-specific Makefiles are immediately available in prod). This does mean that the persistence module may be called twice in a row for certain repos for a short moment of time in prod. Removing the duplicate persistence module calls should be removed from repo-specific Makefiles as a fast-follow after https://github.com/mongodb/docs-worker-pool/pull/889 is released on prod.