### PR TITLE
Add Gatsby Cloud-related webhooks to Enhanced Autobuilder

### DIFF
--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -9,7 +9,7 @@ import { JobStatus } from '../../../src/entities/job';
 import { ECSContainer } from '../../../src/services/containerServices';
 import { SQSConnector } from '../../../src/services/queue';
 import { APIGatewayEvent, APIGatewayProxyResult, SQSEvent, SQSRecord } from 'aws-lambda';
-import { notifyBuildSummary } from '../../handlers/jobs';
+import { notifyBuildSummary, snootyBuildComplete } from '../../handlers/jobs';
 
 export const TriggerLocalBuild = async (event: APIGatewayEvent): Promise<APIGatewayProxyResult> => {
   const consoleLogger = new ConsoleLogger();
@@ -170,3 +170,5 @@ async function NotifyBuildProgress(jobId: string): Promise<void> {
     entitlement['slack_user_id']
   );
 }
+
+export const SnootyBuildComplete = snootyBuildComplete;


### PR DESCRIPTION
### Ticket

DOP-3968

### Notes

* Adds existing v1 webhooks for Gatsby Cloud builds to the enhanced Autobuilder. The logic should be the same for v1 and v2 as they are fully exported from their respective `api/handlers/*.ts` files.
* Envs needed for such webhooks should have already been added in previous PRs, but please let me know if I missed something! Notably, the envs include the following and can be found defined in [default.json](https://github.com/mongodb/docs-worker-pool/blob/ac389132d575eeb8f0035db7d6330f974f611fd8/cdk-infra/static/api/config/default.json), [custom-environment-variables.json](https://github.com/mongodb/docs-worker-pool/blob/ac389132d575eeb8f0035db7d6330f974f611fd8/cdk-infra/static/api/config/custom-environment-variables.json), and [ssm.ts](https://github.com/mongodb/docs-worker-pool/blob/ac389132d575eeb8f0035db7d6330f974f611fd8/cdk-infra/utils/ssm.ts):
  * Snooty secret
  * GitHub bot password
  * GitHub deletion ending