### PR TITLE
Add missing repo branches collection name

### DIFF
--- a/cdk-infra/lib/constructs/api/webhook-env-construct.ts
+++ b/cdk-infra/lib/constructs/api/webhook-env-construct.ts
@@ -21,6 +21,7 @@ export class WebhookEnvConstruct extends Construct {
 
     const dbName = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/dbname`);
     const snootyDbName = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/snooty`);
+    const repoBranchesCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/repo`);
     const dbUsername = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/username`);
     const dbHost = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/host`);
     const jobCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/job/queue`);
@@ -37,6 +38,7 @@ export class WebhookEnvConstruct extends Construct {
       MONGO_ATLAS_URL: `mongodb+srv://${dbUsername}:${dbPassword}@${dbHost}/admin?retryWrites=true`,
       DB_NAME: dbName,
       SNOOTY_DB_NAME: snootyDbName,
+      REPO_BRANCHES_COL_NAME: repoBranchesCollection,
       JOB_QUEUE_COL_NAME: jobCollection,
       NODE_CONFIG_DIR: './config',
       JOBS_QUEUE_URL: jobsQueue.queueUrl,


### PR DESCRIPTION
This PR adds the `REPO_BRANCHES_COL_NAME` env value from Parameter Store to the Webhook/API construct. Seems like this was already added to the Worker construct, so I just followed what was already there.

See `payload.project` in this [build log](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e9160a24fcc731b48f77ef) for updated payload change.