### PR TITLE
DOP-3973: Remove additional call to persistence module

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -61,13 +61,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-atlas-cli
+++ b/makefiles/Makefile.docs-atlas-cli
@@ -45,13 +45,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -53,13 +53,6 @@ next-gen-html:
 	else \
 		exit 0; \
 	fi
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -45,13 +45,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -49,13 +49,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongodb-internal-base
+++ b/makefiles/Makefile.docs-mongodb-internal-base
@@ -48,13 +48,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-mongoid
+++ b/makefiles/Makefile.docs-mongoid
@@ -41,13 +41,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -41,13 +41,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -41,13 +41,6 @@ GH_USER_ARG=${GH_USER}
 endif
 
 next-gen-html:
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	# build-front-end after running parse commands
 	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;

--- a/makefiles/Makefile.docs-stage
+++ b/makefiles/Makefile.docs-stage
@@ -111,13 +111,6 @@ next-gen-html: examples
 			exit 0; \
 		fi \
 	fi
-	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
-	if [ $$? -eq 1 ]; then \
-		exit 1; \
-	else \
-		exit 0; \
-	fi \
 	rsync -az --exclude '.git' ${REPO_DIR}/../../snooty ${REPO_DIR} && \
 	cd snooty && \
 	echo "GATSBY_SITE=${PROJECT}" > .env.production && \


### PR DESCRIPTION
### Ticket

DOP-3973

### Notes

* Removes the call to the persistence module for individual Makefiles.
* I haven't removed the conditional to set `GH_USER_ARG` for the individual Makefiles because I think the existing `shared.mk` only defines it if the individual Makefiles do not define custom build steps. I don't think it should have any negative impact to leave as-is, but can probably be cleaned up in the future