### PR TITLE
DOP-3963: Render only latest version of spec at base spec component

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - "master"
       - "integration"
-      - "DOP-3963"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - "master"
       - "integration"
-      - "POC-base-spec"
+      - "DOP-3963"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - "master"
       - "integration"
+      - "POC-base-spec"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/modules/oas-page-builder/src/services/pageBuilder.ts
+++ b/modules/oas-page-builder/src/services/pageBuilder.ts
@@ -179,7 +179,8 @@ async function getOASpec({
           resourceVersions.length - 1
         ];
 
-        /* POC: build latest Resource Version spec if on base API Version that has multiple Resource Versions */
+        /* Build the latest Resource Version spec if on a base API Version that has multiple Resource Versions
+         * Do not build the base API VERSION, since it may have out of order resources*/
         const { oasFileURL, successfulGitHash } = await getAtlasSpecUrl({
           apiKeyword: source,
           apiVersion,

--- a/modules/oas-page-builder/tests/unit/services/pageBuilder.test.ts
+++ b/modules/oas-page-builder/tests/unit/services/pageBuilder.test.ts
@@ -192,7 +192,7 @@ describe('pageBuilder', () => {
 
     await buildOpenAPIPages(testEntries, testOptions);
 
-    expect(mockExecute).toBeCalledTimes(testEntries.length * 2);
+    expect(mockExecute).toBeCalledTimes(4);
     // Local
     expect(mockExecute).toBeCalledWith(
       `${testOptions.repo}/source${testEntries[0][1].source}`,
@@ -201,12 +201,6 @@ describe('pageBuilder', () => {
       getExpectedVersionOptions(`${SITE_URL}/${testEntries[0][0]}`)
     );
 
-    expect(mockExecute).toBeCalledWith(
-      `${testOptions.repo}/source${testEntries[0][1].source}`,
-      `${testOptions.output}/${testEntries[0][0]}/index.html`,
-      expectedDefaultBuildOptions,
-      getExpectedVersionOptions(`${SITE_URL}/${testEntries[0][0]}`)
-    );
     // Url
     expect(mockExecute).toBeCalledWith(
       `${testEntries[1][1].source}`,
@@ -215,12 +209,6 @@ describe('pageBuilder', () => {
       getExpectedVersionOptions(`${SITE_URL}/${testEntries[1][0]}`)
     );
 
-    expect(mockExecute).toBeCalledWith(
-      `${testEntries[1][1].source}`,
-      getExpectedOutputPath(testOptions.output, testEntries[1][0], API_VERSION),
-      expectedDefaultBuildOptions,
-      getExpectedVersionOptions(`${SITE_URL}/${testEntries[1][0]}`)
-    );
     // Atlas
     expect(mockExecute).toBeCalledWith(
       `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/${MOCKED_GIT_HASH}-v2-${RESOURCE_VERSION}.json`,
@@ -230,8 +218,8 @@ describe('pageBuilder', () => {
     );
 
     expect(mockExecute).toBeCalledWith(
-      `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/${MOCKED_GIT_HASH}-v2.json`,
-      getExpectedOutputPath(testOptions.output, testEntries[2][0], API_VERSION),
+      `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/${MOCKED_GIT_HASH}-v2-${RESOURCE_VERSION}.json`,
+      getExpectedOutputPath(testOptions.output, testEntries[2][0], API_VERSION, RESOURCE_VERSION),
       expectedAtlasBuildOptions,
       getExpectedVersionOptions(`${SITE_URL}/${testEntries[2][0]}`)
     );
@@ -280,8 +268,8 @@ describe('pageBuilder', () => {
     );
 
     expect(mockExecute).toBeCalledWith(
-      `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/${MOCKED_GIT_HASH}-v2.json`,
-      getExpectedOutputPath(testOptions.output, testEntries[0][0], API_VERSION),
+      `https://mongodb-mms-prod-build-server.s3.amazonaws.com/openapi/${MOCKED_GIT_HASH}-v2-${LATEST_RESOURCE_VERSION}.json`,
+      getExpectedOutputPath(testOptions.output, testEntries[0][0], API_VERSION, LATEST_RESOURCE_VERSION),
       expectedAtlasBuildOptions,
       getExpectedVersionOptions(`${SITE_URL}/${testEntries[0][0]}`, LATEST_RESOURCE_VERSION)
     );


### PR DESCRIPTION
# Context
DOP-3963 has most details, but TLDR: 

We want to render only the latest spec at the base route of any versioned OpenAPI spec - this resolves some out-of-order issues with resources in dropdowns vs version in the left sidenav, and consumers of the spec typically want to see the latest versions regardless.

## Staging Link
https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/master/reference/api-resources-spec/v2/