### PR TITLE
DOP-3977: encourage writers to switch webhooks 🥕

### DIFF
--- a/api/controllers/v1/jobs.ts
+++ b/api/controllers/v1/jobs.ts
@@ -179,7 +179,7 @@ function prepProgressMessage(
         const webhookWikiUrl =
           'https://wiki.corp.mongodb.com/display/DE/How-To%3A+Use+Snooty%27s+Autobuilder+to+Build+Your+Content';
         const updatePlease = `:exclamation: You used the old webhook for this build. <${webhookWikiUrl}|Update to the new webhook> in your fork of this repo to save 90s per build.`;
-        inQueueMsg = updatePlease + '\n' + msg;
+        inQueueMsg = updatePlease + '\n\n' + msg;
       }
       return inQueueMsg + 'has successfully been added to the ' + env + ' queue.';
     case 'inProgress':

--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -122,7 +122,7 @@ function prepProgressMessage(
         const webhookWikiUrl =
           'https://wiki.corp.mongodb.com/display/DE/How-To%3A+Use+Snooty%27s+Autobuilder+to+Build+Your+Content';
         const updatePlease = `:exclamation: You used the old webhook for this build. <${webhookWikiUrl}|Update to the new webhook> in your fork of this repo to save 90s per build.`;
-        inQueueMsg = updatePlease + '\n' + msg;
+        inQueueMsg = updatePlease + '\n\n' + msg;
       }
       return inQueueMsg + 'has successfully been added to the ' + env + ' queue.';
     case 'inProgress':

--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -108,13 +108,23 @@ function prepProgressMessage(
   jobId: string,
   jobTitle: string,
   status: string,
-  errorReason: string
+  errorReason: string,
+  jobType?: string
 ): string {
   const msg = `Your Job (<${jobUrl}${jobId}|${jobTitle}>) `;
   const env = c.get<string>('env');
+
   switch (status) {
     case 'inQueue':
-      return msg + 'has successfully been added to the ' + env + ' queue.';
+      // Encourage writers to update to new webhook on githubPush jobs
+      let inQueueMsg = msg;
+      if (jobType == 'githubPush') {
+        const webhookWikiUrl =
+          'https://wiki.corp.mongodb.com/display/DE/How-To%3A+Use+Snooty%27s+Autobuilder+to+Build+Your+Content';
+        const updatePlease = `:exclamation: You used the old webhook for this build. <${webhookWikiUrl}|Update to the new webhook> in your fork of this repo to save 90s per build.`;
+        inQueueMsg = updatePlease + '\n' + msg;
+      }
+      return inQueueMsg + 'has successfully been added to the ' + env + ' queue.';
     case 'inProgress':
       return msg + 'is now being processed.';
     case 'completed':
@@ -165,7 +175,8 @@ async function NotifyBuildProgress(jobId: string): Promise<void> {
       jobId,
       jobTitle,
       fullDocument.status as string,
-      fullDocument?.error?.reason || ''
+      fullDocument?.error?.reason || '',
+      fullDocument?.payload.jobType
     ),
     entitlement['slack_user_id']
   );

--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -108,23 +108,13 @@ function prepProgressMessage(
   jobId: string,
   jobTitle: string,
   status: string,
-  errorReason: string,
-  jobType?: string
+  errorReason: string
 ): string {
   const msg = `Your Job (<${jobUrl}${jobId}|${jobTitle}>) `;
   const env = c.get<string>('env');
-
   switch (status) {
     case 'inQueue':
-      // Encourage writers to update to new webhook on githubPush jobs
-      let inQueueMsg = msg;
-      if (jobType == 'githubPush') {
-        const webhookWikiUrl =
-          'https://wiki.corp.mongodb.com/display/DE/How-To%3A+Use+Snooty%27s+Autobuilder+to+Build+Your+Content';
-        const updatePlease = `:exclamation: You used the old webhook for this build. <${webhookWikiUrl}|Update to the new webhook> in your fork of this repo to save 90s per build.`;
-        inQueueMsg = updatePlease + '\n\n' + msg;
-      }
-      return inQueueMsg + 'has successfully been added to the ' + env + ' queue.';
+      return msg + 'has successfully been added to the ' + env + ' queue.';
     case 'inProgress':
       return msg + 'is now being processed.';
     case 'completed':
@@ -175,8 +165,7 @@ async function NotifyBuildProgress(jobId: string): Promise<void> {
       jobId,
       jobTitle,
       fullDocument.status as string,
-      fullDocument?.error?.reason || '',
-      fullDocument?.payload.jobType
+      fullDocument?.error?.reason || ''
     ),
     entitlement['slack_user_id']
   );


### PR DESCRIPTION
Adds blurb to encourage writers to update to the new webhook. I am very open to copy enhancement suggestions.

Message for build on non-enhanced stg webhook:
![Screenshot 2023-08-31 at 12 17 16 PM](https://github.com/mongodb/docs-worker-pool/assets/1724699/2121e71f-d0a8-4ef1-a935-12ff15bb3d82)

Message for build on enhanced stg webhook:
![Screenshot 2023-08-31 at 12 20 23 PM](https://github.com/mongodb/docs-worker-pool/assets/1724699/5dc5f786-a4ac-4bae-8801-29039025d93a)


Message for /test-deploy:
![Screenshot 2023-08-31 at 12 20 01 PM](https://github.com/mongodb/docs-worker-pool/assets/1724699/d8be95bc-e556-41f5-832f-636dc6b6efe1)

