### PR TITLE
[BUGFIX]: Fix duplicate parameter deploy error 

### DIFF
--- a/cdk-infra/lib/constructs/api/webhook-env-construct.ts
+++ b/cdk-infra/lib/constructs/api/webhook-env-construct.ts
@@ -3,7 +3,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 import { getSsmPathPrefix } from '../../../utils/ssm';
 import { getDashboardUrl } from '../../../utils/slack';
-import { getEnv } from '../../../utils/env';
+import { getEnv, getFeatureName } from '../../../utils/env';
 
 interface WebhookEnvConstructProps {
   jobsQueue: IQueue;
@@ -18,10 +18,11 @@ export class WebhookEnvConstruct extends Construct {
 
     const ssmPrefix = getSsmPathPrefix();
     const env = getEnv();
+    const featureName = getFeatureName();
 
     // Create configurable feature flag that lives in parameter store.
     const monorepoPathFeature = new StringParameter(this, 'monorepoPathFeature', {
-      parameterName: `${ssmPrefix}/monorepo/path_feature`,
+      parameterName: `${ssmPrefix}/${featureName}/monorepo/path_feature`,
       stringValue: env === 'dotcomstg' || env === 'stg' ? 'true' : 'false',
     });
 


### PR DESCRIPTION
When attempting to deploy another feature branch stack, I ran into an error stating that I had a duplicate parameter store value when deploying my change. This is due to the fact that I added code to create a new parameter store value in the CDK. 


[Failed job for reference](https://github.com/mongodb/docs-worker-pool/actions/runs/6192385254/job/16812369888)
```sh

Failed resources:
auto-builder-stack-enhancedApp-stg-docker-buildspeed-poc-webhooks | 12:49:16 AM | CREATE_FAILED        | AWS::SSM::Parameter             | ssmVars/monorepoPathFeature (ssmVarsmonorepoPathFeature488111CB) /env/stg/docs/worker_pool/monorepo/path_feature already exists in stack arn:aws:cloudformation:us-east-2:***:stack/auto-builder-stack-enhancedApp-stg-webhooks/c7b84a20-3865-11ee-9bbf-0a716bdfa1cb**

```

To resolve this issue, I added the `featureName` as a part of the path for the feature flag. I believe this is also desirable even if the error did not occur, as we would be able to change the feature flag value without impacting other environments, which is the intended goal of working with feature branches in the first place.

## Testing

The test to verify that this change works as intended is to make sure the feature branch infrastructure deploys without error. 
