### PR TITLE
DOP-4013: add bson-ruby submodule for tutorial

### DIFF
--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -60,6 +60,7 @@ get-build-dependencies: fetch-submodule
 fetch-submodule:
 	git submodule update --remote --init
 	rsync -a --delete ${REPO_DIR}/mongo-ruby-driver/docs/ ${REPO_DIR}/source
+	rsync -a --delete ${REPO_DIR}/bson-ruby/docs/tutorials/bson-v4.txt ${REPO_DIR}/source/tutorials/bson-v4
 
 next-gen-stage: ## Host online for review
 	# stagel local jobs \


### PR DESCRIPTION
The ruby docs should include a tutorial whose docs live in the mongodb/bson-ruby repository. We've added the bson-ruby submodule to the source; this will rsync the relevant file into the relevant directory. Tested locally with satisfactory outcome.