### PR TITLE
DOP-3723: Pass Autobuilder job ID to persistence module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ worker/coverage
 worker/work
 worker/docs-tools
 worker/repos/*
+cdk-infra/*
+modules/*

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -90,7 +90,7 @@ endif
 
 persistence-module:
 	# persistence module - add bundle zip to Atlas documents
-	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG}
+	node --unhandled-rejections=strict ${PERSISTENCE_MODULE_PATH} --path ${BUNDLE_PATH} --githubUser ${GH_USER_ARG} --jobId ${JOB_ID}
 	if [ $$? -eq 1 ]; then \
 		exit 1; \
 	else \


### PR DESCRIPTION
### Ticket

DOP-3723

### Notes

* Passes down an Autobuilder job ID to the persistence module.
* Related Autobuilder change can be found at #913.