### PR TITLE
DOP-4096: Create new timestamp when inserting pages and metadata

### DIFF
--- a/modules/persistence/src/services/connector/index.ts
+++ b/modules/persistence/src/services/connector/index.ts
@@ -47,7 +47,7 @@ export const insert = async (docs: any[], collection: string, buildId: ObjectId,
       docs.map((d) => ({
         ...d,
         build_id: buildId,
-        created_at: buildId.getTimestamp(),
+        created_at: new Date(),
       })),
       { ordered: false }
     );


### PR DESCRIPTION
### Ticket

DOP-4096

### Notes

* This should hopefully prevent (or at least minimize) the issue we've been seeing with missing metadata during Gatsby Cloud builds. The idea is that the `created_at` timestamp would be skewed due to using the Autobuilder job ID's timestamp, leading to fetches from the Gatsby preview source plugin and Snooty Data API skipping over data during parallel builds. The ticket has more context, along with the associated frontend PR that handles generating warnings for this event