### PR TITLE
DOP-4079 follow-up - ensure monorepo jobs access correct Makefiles

### DIFF
--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -37,11 +37,11 @@ help:
 	@echo '  ARGS         - Arguments to pass to mut-publish'
 
 ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
-    # Found
-		RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/cloud-docs
+	# Found
+	RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/cloud-docs
 else
-    # Not found
-		RELATIVE_PATH_OF_PUB_BRANCHES=cloud-docs
+	# Not found
+	RELATIVE_PATH_OF_PUB_BRANCHES=cloud-docs
 endif
 
 get-build-dependencies:

--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -38,4 +38,4 @@ help:
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-monorepo/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{REPO_DIR}.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -36,6 +36,13 @@ help:
 	@echo 'Variables'
 	@echo '  ARGS         - Arguments to pass to mut-publish'
 
+ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
+    # Found
+		RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/cloud-docs
+else
+    # Not found
+		RELATIVE_PATH_OF_PUB_BRANCHES=cloud-docs
+endif
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{REPO_DIR}.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{RELATIVE_PATH_OF_PUB_BRANCHES}.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -38,4 +38,4 @@ help:
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/publishedbranches/docs-monorepo/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.cloud-docs
+++ b/makefiles/Makefile.cloud-docs
@@ -38,4 +38,4 @@ help:
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/publishedbranches/docs-monorepo/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-monorepo/cloud-docs.yaml > ${REPO_DIR}/published-branches.yaml

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -45,6 +45,14 @@ else
 GH_USER_ARG=${GH_USER}
 endif
 
+ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
+    # Found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
+else
+    # Not found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
+endif
+
 next-gen-html:
 	# snooty parse and then build-front-end
 	snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG}; \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -18,7 +18,7 @@ DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/publishedbranches/docs-monorepo/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-monorepo/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml
 
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -16,9 +16,19 @@ include ~/shared.mk
 DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
 
 
+ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
+    # Found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
+		RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/docs-landing
+else
+    # Not found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
+		RELATIVE_PATH_OF_PUB_BRANCHES=docs-landing
+endif
+
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{REPO_DIR}.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{RELATIVE_PATH_OF_PUB_BRANCHES}.yaml > ${REPO_DIR}/published-branches.yaml
 
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen
@@ -43,14 +53,6 @@ ifeq ($(GH_USER),)
 GH_USER_ARG=docs-builder-bot
 else
 GH_USER_ARG=${GH_USER}
-endif
-
-ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
-    # Found
-		PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
-else
-    # Not found
-		PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
 endif
 
 next-gen-html:

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -18,7 +18,7 @@ DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/publishedbranches/docs-monorepo/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml
 
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -17,13 +17,13 @@ DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
 
 
 ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
-    # Found
-		PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
-		RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/docs-landing
+	# Found
+	PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
+	RELATIVE_PATH_OF_PUB_BRANCHES=docs-monorepo/docs-landing
 else
-    # Not found
-		PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
-		RELATIVE_PATH_OF_PUB_BRANCHES=docs-landing
+	# Not found
+	PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
+	RELATIVE_PATH_OF_PUB_BRANCHES=docs-landing
 endif
 
 

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -61,7 +61,7 @@ next-gen-html:
 	else \
 		exit 0; \
 	fi
-	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
+	rsync -az --exclude '.git' "${PATH_TO_SNOOTY}" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -18,7 +18,7 @@ DOCS_TOOLS_THEME=docs-tools/themes/mongodb/static
 
 
 get-build-dependencies:
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-monorepo/docs-landing.yaml > ${REPO_DIR}/published-branches.yaml
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/{REPO_DIR}.yaml > ${REPO_DIR}/published-branches.yaml
 
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -56,9 +56,17 @@ else
 GH_USER_ARG=${GH_USER}
 endif
 
+ifneq (,$(findstring docs-monorepo,$(REPO_DIR)))
+    # Found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../../snooty
+else
+    # Not found
+		PATH_TO_SNOOTY=${REPO_DIR}/../../snooty
+endif
+
 next-gen-html:
 	# build-front-end after running parse commands
-	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
+	rsync -az --exclude '.git' "${PATH_TO_SNOOTY}" "${REPO_DIR}"
 	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
 	cd snooty; \
 	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \

--- a/publishedbranches/docs-monorepo/cloud-docs.yaml
+++ b/publishedbranches/docs-monorepo/cloud-docs.yaml
@@ -1,0 +1,15 @@
+prefix: '/'
+version:
+  published:
+    - 'master'
+  active:
+    - 'master'
+  stable: 'master'
+git:
+  branches:
+    manual: 'master'
+    published:
+      - 'master'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...

--- a/publishedbranches/docs-monorepo/docs-landing.yaml
+++ b/publishedbranches/docs-monorepo/docs-landing.yaml
@@ -1,0 +1,16 @@
+prefix: '/'
+version:
+  published:
+    - 'master'
+  active:
+    - 'master'
+  stable: ''
+  upcoming: master
+git:
+  branches:
+    manual: 'master'
+    published:
+      - 'master'
+      # the branches/published list **must** be ordered from most to
+      # least recent release.
+...


### PR DESCRIPTION
### Ticket

DOP-4079

### Notes

As a follow-up to [PR 929](https://github.com/mongodb/docs-worker-pool/pull/929), this alteration to the `meta` branch is necessary for successful monorepo `Job` builds. 

Both changes have to do with the now-double-layered monorepo paradigm (ie. `docs-monorepo/cloud-docs` vs `cloud-docs`).

1. The new PATH_TO_SNOOTY correctly points to the directory level where Snooty is installed. 
2. New publishedBranches files to account for the nested level of all requests. In the future, would love to not have duplicates such as these, but with our Makefiles being removed soon - it could just be a small necessary evil for now