### PR TITLE
Change ref back to `meta`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ USER docsworker-xlarge
 WORKDIR ${WORK_DIRECTORY}
 
 # get shared.mk
-RUN curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/makefiles/shared.mk -o shared.mk
+RUN curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/shared.mk -o shared.mk
 
 # install snooty frontend and docs-tools
 RUN git clone -b v${SNOOTY_FRONTEND_VERSION} --depth 1 https://github.com/mongodb/snooty.git       \

--- a/Dockerfile.enhanced
+++ b/Dockerfile.enhanced
@@ -74,7 +74,7 @@ USER docsworker-xlarge
 WORKDIR ${WORK_DIRECTORY}
 
 # get shared.mk
-RUN curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/makefiles/shared.mk -o shared.mk
+RUN curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/shared.mk -o shared.mk
 
 # install snooty frontend and docs-tools
 RUN git clone -b v${SNOOTY_FRONTEND_VERSION} --depth 1 https://github.com/mongodb/snooty.git       \

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -210,7 +210,7 @@ export abstract class JobHandler {
           ? this.currJob.payload.directory
           : this.currJob.payload.repoName;
       await this._fileSystemServices.saveUrlAsFile(
-        `https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/makefiles/Makefile.${makefileFileName}`,
+        `https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/Makefile.${makefileFileName}`,
         `repos/${getDirectory(this.currJob)}/Makefile`,
         {
           encoding: 'utf8',

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -120,7 +120,7 @@ describe('ProductionJobHandler Tests', () => {
   test('Execute throws error when Downloading makefile repo should update status', async () => {
     jobHandlerTestHelper.fileSystemServices.saveUrlAsFile
       .calledWith(
-        `https://raw.githubusercontent.com/mongodb/docs-worker-pool/monorepo-pub-branches/makefiles/Makefile.${jobHandlerTestHelper.job.payload.repoName}`
+        `https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/Makefile.${jobHandlerTestHelper.job.payload.repoName}`
       )
       .mockImplementation(() => {
         throw new Error('Error while Downloading makefile');


### PR DESCRIPTION
Work on previous PR depended on changes to the meta branch that were present in `monorepo-pub-branches`. This PR resets all of these references back to the correct `meta` branch.