### PR TITLE
DOP-3998: allow preprd to use URL for search staging server

### DIFF
--- a/.github/workflows/deploy-feature-branch.yml
+++ b/.github/workflows/deploy-feature-branch.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
 name: Initial Feature Branch Deploy
 jobs: 
   deploy:

--- a/.github/workflows/deploy-feature-branch.yml
+++ b/.github/workflows/deploy-feature-branch.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - reopened
+      - edited
 name: Initial Feature Branch Deploy
 jobs: 
   deploy:

--- a/Dockerfile.enhanced
+++ b/Dockerfile.enhanced
@@ -23,7 +23,7 @@ RUN cd ./modules/oas-page-builder \
 FROM ubuntu:20.04
 ARG WORK_DIRECTORY=/home/docsworker-xlarge
 ARG SNOOTY_PARSER_VERSION=0.15.0
-ARG SNOOTY_FRONTEND_VERSION=0.15.1.1b
+ARG SNOOTY_FRONTEND_VERSION=DOP-3998
 ARG MUT_VERSION=0.10.7
 ARG REDOC_CLI_VERSION=1.2.2
 ARG NPM_BASE_64_AUTH
@@ -77,7 +77,7 @@ WORKDIR ${WORK_DIRECTORY}
 RUN curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/makefiles/shared.mk -o shared.mk
 
 # install snooty frontend and docs-tools
-RUN git clone -b v${SNOOTY_FRONTEND_VERSION} --depth 1 https://github.com/mongodb/snooty.git       \
+RUN git clone -b ${SNOOTY_FRONTEND_VERSION} --depth 1 https://github.com/mongodb/snooty.git       \
     && cd snooty                                                                                   \
     && npm ci --legacy-peer-deps --omit=dev                                                        \
     && git clone --depth 1 https://github.com/mongodb/docs-tools.git                               \

--- a/cdk-infra/lib/constructs/worker/worker-env-construct.ts
+++ b/cdk-infra/lib/constructs/worker/worker-env-construct.ts
@@ -59,6 +59,7 @@ export class WorkerEnvConstruct extends Construct {
     const repoBranchesCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/repo`);
     const docsetsCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/docsets`);
     const jobCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/job/queue`);
+    const gatsbyMarianUrl = StringParameter.valueFromLookup(this, `${ssmPrefix}/frontend/marian_url`);
 
     const dbPassword = secureStrings['MONGO_ATLAS_PASSWORD'];
     this.environment = {
@@ -93,6 +94,7 @@ export class WorkerEnvConstruct extends Construct {
       GATSBY_TEST_SEARCH_UI: 'false',
       GATSBY_SHOW_CHATBOT: gatsbyUseChatbot,
       GATSBY_HIDE_UNIFIED_FOOTER_LOCALE: gatsbyHideUnifiedFooterLocale,
+      GATSBY_MARIAN_URL: gatsbyMarianUrl,
     };
   }
 }

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -25,6 +25,7 @@
   "featureFlagSearchUI": "GATSBY_TEST_SEARCH_UI",
   "gatsbyUseChatbot": "GATSBY_SHOW_CHATBOT",
   "gatsbyHideUnifiedFooterLocale": "GATSBY_HIDE_UNIFIED_FOOTER_LOCALE",
+  "gatsbyManifestURL": "GATSBY_MARIAN_URL",
   "repoBranchesCollection": "REPO_BRANCHES_COL_NAME",
   "docsetsCollection": "DOCSETS_COL_NAME",
   "repo_dir": "repos",

--- a/config/default.json
+++ b/config/default.json
@@ -21,6 +21,7 @@
   "PORT": 3000,
   "MAX_STDOUT_BUFFER_SIZE": 16000000,
   "GATSBY_PARSER_USER": "docsworker-xlarge",
+  "gatsbyMarianUrl": "https://docs-search-transport.mongodb.com/",
   "gatsbyTestEmbedVersions": false,
   "fastlyOpsManagerToken": "FASTLY_OPS_MANAGER_TOKEN",
   "fastlyOpsManagerServiceId": "FASTLY_OPS_MANAGER_SERVICE_ID",

--- a/infrastructure/ecs-main/ecs_service.yml
+++ b/infrastructure/ecs-main/ecs_service.yml
@@ -68,6 +68,8 @@ Resources:
               Value: ${self:custom.featureFlagSearchUI}
             - Name: GATSBY_SHOW_CHATBOT
               Value: ${self:custom.gatsbyUseChatbot}
+            - Name: GATSBY_MARIAN_URL
+              Value: ${self:custom.gatsbyMarianUrl}
             - Name: GATSBY_HIDE_UNIFIED_FOOTER_LOCALE
               Value: ${self:custom.gatsbyHideUnifiedFooterLocale}
             - Name: FASTLY_MAIN_TOKEN

--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -120,6 +120,7 @@ custom:
   gatsbyTestEmbedVersions: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/embedded_versions}
   gatsbyUseChatbot: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/use_chatbot}
   gatsbyHideUnifiedFooterLocale: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/hide_locale}
+  gatsbyManifestURL: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/marian_url}
   fastlyMainToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/token}
   fastlyMainServiceId: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/service_id}
   fastlyCloudManagerToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/cloudmanager/token}

--- a/src/commands/src/helpers/dependency-helpers.ts
+++ b/src/commands/src/helpers/dependency-helpers.ts
@@ -23,6 +23,7 @@ async function createEnvProdFile(repoDir: string, projectName: string, baseUrl: 
       GATSBY_MANIFEST_PATH=${repoDir}/bundle.zip
       GATSBY_PARSER_USER=${process.env.USER}
       GATSBY_BASE_URL=${baseUrl}
+      GATSBY_MARIAN_URL=${process.env.GATSBY_MARIAN_URL}
       PATH_PREFIX=${prefix}`,
       'utf8'
     );

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -375,6 +375,7 @@ export abstract class JobHandler {
       GATSBY_TEST_SEARCH_UI: this._config.get<string>('featureFlagSearchUI'),
       GATSBY_SHOW_CHATBOT: this._config.get<string>('gatsbyUseChatbot'),
       GATSBY_HIDE_UNIFIED_FOOTER_LOCALE: this._config.get<string>('gatsbyHideUnifiedFooterLocale'),
+      GATSBY_MARIAN_URL: this._config.get<string>('gatsbyManifestURL'),
     };
 
     for (const [envName, envValue] of Object.entries(snootyFrontEndVars)) {

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -176,7 +176,7 @@ export class TestDataProvider {
   }
 
   static getEnvVarsWithPathPrefixWithFlags(job: Job): string {
-    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_SHOW_CHATBOT=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\n`;
+    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_SHOW_CHATBOT=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\nGATSBY_MARIAN_URL=test-url\n`;
   }
 
   static getPathPrefixCases(): Array<any> {

--- a/tests/unit/job/productionJobHandler.test.ts
+++ b/tests/unit/job/productionJobHandler.test.ts
@@ -247,7 +247,7 @@ describe('ProductionJobHandler Tests', () => {
 
     expect(jobHandlerTestHelper.fileSystemServices.writeToFile).toBeCalledWith(
       `repos/${jobHandlerTestHelper.job.payload.repoName}/.env.production`,
-      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_SHOW_CHATBOT=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\n`,
+      `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${jobHandlerTestHelper.job.payload.branchName}\nPATH_PREFIX=/\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_SHOW_CHATBOT=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\nGATSBY_MARIAN_URL=test-url\n`,
       { encoding: 'utf8', flag: 'w' }
     );
   });

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -154,6 +154,7 @@ export class JobHandlerTestHelper {
     this.config.get.calledWith('featureFlagSearchUI').mockReturnValue('false');
     this.config.get.calledWith('gatsbyUseChatbot').mockReturnValue('false');
     this.config.get.calledWith('gatsbyHideUnifiedFooterLocale').mockReturnValue('true');
+    this.config.get.calledWith('gatsbyManifestURL').mockReturnValue('test-url');
     this.repoConnector.checkCommits
       .calledWith(this.job)
       .mockReturnValue(TestDataProvider.getCommitCheckValidResponse(this.job));


### PR DESCRIPTION
**PR description:**
- this PR allows autobuilder to pipe in a front end variable `GATSBY_MARIAN_URL` to let the [client side know which search server](https://github.com/mongodb/snooty/blob/master/src/constants.js#L15) to point to.
- AWS parameter store values have been stored, with `stg` environment pointing to stage search url `https://docs-search-transport.docs.staging.corp.mongodb.com/`

![image](https://github.com/mongodb/docs-worker-pool/assets/13054820/4d86903e-72c2-4de5-a978-919fdc8801de)

![image](https://github.com/mongodb/docs-worker-pool/assets/13054820/9706f40f-5717-46f3-8b70-555eeb81e7cb)


**PREREQ prs**
[search transport server must allow CORS authentication](https://github.com/mongodb/docs-search-transport/pull/89)
[front end must supply credentials when making requests to authenticate through corpsecure](https://github.com/mongodb/snooty/pull/959)




**Sample of change**
[Staged site, making requests to staging search server (will have to be authenticated in same browser to make send credentials)](https://docs-mongodbcom-staging.corp.mongodb.com/newhomepagewhodis/landing/seung.park/DOP-3998/search/?q=atlas&page=1)