### PR TITLE
DOP-3998: use same name for env vars

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -25,7 +25,7 @@
   "featureFlagSearchUI": "GATSBY_TEST_SEARCH_UI",
   "gatsbyUseChatbot": "GATSBY_SHOW_CHATBOT",
   "gatsbyHideUnifiedFooterLocale": "GATSBY_HIDE_UNIFIED_FOOTER_LOCALE",
-  "gatsbyManifestURL": "GATSBY_MARIAN_URL",
+  "gatsbyMarianURL": "GATSBY_MARIAN_URL",
   "repoBranchesCollection": "REPO_BRANCHES_COL_NAME",
   "docsetsCollection": "DOCSETS_COL_NAME",
   "repo_dir": "repos",

--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -120,7 +120,7 @@ custom:
   gatsbyTestEmbedVersions: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/embedded_versions}
   gatsbyUseChatbot: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/use_chatbot}
   gatsbyHideUnifiedFooterLocale: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/hide_locale}
-  gatsbyManifestURL: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/marian_url}
+  gatsbyMarianURL: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/marian_url}
   fastlyMainToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/token}
   fastlyMainServiceId: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/service_id}
   fastlyCloudManagerToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/cloudmanager/token}

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -375,7 +375,7 @@ export abstract class JobHandler {
       GATSBY_TEST_SEARCH_UI: this._config.get<string>('featureFlagSearchUI'),
       GATSBY_SHOW_CHATBOT: this._config.get<string>('gatsbyUseChatbot'),
       GATSBY_HIDE_UNIFIED_FOOTER_LOCALE: this._config.get<string>('gatsbyHideUnifiedFooterLocale'),
-      GATSBY_MARIAN_URL: this._config.get<string>('gatsbyManifestURL'),
+      GATSBY_MARIAN_URL: this._config.get<string>('gatsbyMarianURL'),
     };
 
     for (const [envName, envValue] of Object.entries(snootyFrontEndVars)) {

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -154,7 +154,7 @@ export class JobHandlerTestHelper {
     this.config.get.calledWith('featureFlagSearchUI').mockReturnValue('false');
     this.config.get.calledWith('gatsbyUseChatbot').mockReturnValue('false');
     this.config.get.calledWith('gatsbyHideUnifiedFooterLocale').mockReturnValue('true');
-    this.config.get.calledWith('gatsbyManifestURL').mockReturnValue('test-url');
+    this.config.get.calledWith('gatsbyMarianURL').mockReturnValue('test-url');
     this.repoConnector.checkCommits
       .calledWith(this.job)
       .mockReturnValue(TestDataProvider.getCommitCheckValidResponse(this.job));


### PR DESCRIPTION
Follow up to [previous PR](https://github.com/mongodb/docs-worker-pool/pull/942)

Above PR is causing [staging build errors](https://github.com/mongodb/docs-worker-pool/actions/runs/7009848133/job/19069167991) due to [env variable names differing](https://github.com/mongodb/docs-worker-pool/pull/937/files#diff-822cad868abefc13eb54d59cc2aedb564b3dd0fab6ca48047e2dbbb13ddb2875R28) (fix is [here](https://github.com/mongodb/docs-worker-pool/pull/943/files#diff-822cad868abefc13eb54d59cc2aedb564b3dd0fab6ca48047e2dbbb13ddb2875L28))