### PR TITLE
Bugfix: Optional chaining to shortcircuit error with container

### DIFF
--- a/src/services/containerServices.ts
+++ b/src/services/containerServices.ts
@@ -97,7 +97,7 @@ export class ECSContainer implements IContainerServices {
       });
 
       // Only stop ECS task if it's still running
-      if (res.tasks?.[0].lastStatus === 'RUNNING') {
+      if (res.tasks?.[0]?.lastStatus === 'RUNNING') {
         await this._client.stopTask({
           cluster: clusterName,
           task: taskId,


### PR DESCRIPTION
Just saw this error in Cloudwatch. Honestly not sure if this was from what I'm dealing with, but I found this in the code and thought it might be worth adding to make sure this kind of error doesn't occur. 

Error seen in Cloudwatch:

```{
    "errorType": "TypeError",
    "errorMessage": "Cannot read properties of undefined (reading 'lastStatus')",
    "stack": [
        "TypeError: Cannot read properties of undefined (reading 'lastStatus')",
        "    at ECSContainer.stopZombieECSTask (/var/task/api/controllers/v1/jobs.js:78232:25)",
        "    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
        "    at async stopECSTask (/var/task/api/controllers/v1/jobs.js:78815:3)",
        "    at async /var/task/api/controllers/v1/jobs.js:78761:15",
        "    at async Promise.all (index 0)",
        "    at async Runtime.HandleJobs [as handler] (/var/task/api/controllers/v1/jobs.js:78734:3)"
    ]
}
```

[Link to Cloudwatch error](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdocs-worker-pool-api-prd-v1HandleJobs/log-events/2023$252F12$252F07$252F$255B$2524LATEST$255D76c3573851a24f029d377fe5aa9ad066)