### PR TITLE
DOP-4192: Add Makefile for docs-laravel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ worker/docs-tools
 worker/repos/*
 cdk-infra/*
 modules/*
+dist/*

--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -1,0 +1,21 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+ifeq ($(STAGING_USERNAME),)
+	USER=$(shell whoami)
+else
+	USER=$(STAGING_USERNAME)
+endif
+
+PROJECT=laravel
+MUT_PREFIX ?= $(PROJECT)
+
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	echo "Published branches information stored in Atlas collection"


### PR DESCRIPTION
### Ticket

DOP-4192

### Notes

* Made a barebones Makefile for the new `docs-laravel` repo. I don't believe this has any crazy build steps, so I kept it as minimal as possible.
* (Bonus) Added `dist/` to the `.gitignore` file to allow for a seamless transition between local Autobuilder usage and `meta` branch updates. Otherwise, `dist/` might appear and can accidentally be added to the commit.