### PR TITLE
DOP-4237: Fetch submodules for docs-laravel

### DIFF
--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -16,6 +16,9 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
+fetch-submodule:
+	git submodule update --remote --init
+	rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source
 
-get-build-dependencies: 
+get-build-dependencies: fetch-submodule
 	echo "Published branches information stored in Atlas collection"

--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -73,6 +73,4 @@ get-build-dependencies:
 
 fetch-submodule:
 	git submodule update --remote --init
-	if [ -d "${REPO_DIR}/laravel-mongodb/docs" ]; then \
-		rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source; \
-	fi
+	rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source

--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -6,19 +6,71 @@ else
 	USER=$(STAGING_USERNAME)
 endif
 
+REPO_DIR=$(shell pwd)
+
 PROJECT=laravel
 MUT_PREFIX ?= $(PROJECT)
-
-REPO_DIR=$(shell pwd)
 
 SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
 SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
+# Necessary to add the fetch-submodule dependency
+PUSHLESS_DEPLOY_SHARED_DISABLED=true
+
 include ~/shared.mk
+
+next-gen-parse: fetch-submodule
+	# snooty parse -- separated from front-end to support index gen
+	@if [ -n "${PATCH_ID}" ]; then \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG}; \
+		if [ $$? -eq 1 ]; then \
+			exit 1; \
+		else \
+			exit 0; \
+		fi \
+	else \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG}; \
+		if [ $$? -eq 1 ]; then \
+			exit 1; \
+		else \
+			exit 0; \
+		fi \
+	fi
+
+# Set Github user to docs-builder-bot if empty
+ifeq ($(GH_USER),)
+GH_USER_ARG=docs-builder-bot
+else
+GH_USER_ARG=${GH_USER}
+endif
+
+next-gen-html:
+	# build-front-end after running parse commands
+	rsync -az --exclude '.git' "${REPO_DIR}/../../snooty" "${REPO_DIR}"
+	cp ${REPO_DIR}/.env.production ${REPO_DIR}/snooty;
+	cd snooty; \
+	echo "GATSBY_SITE=${PROJECT}" >> .env.production; \
+	if [ -n "${PATCH_ID}" ]; then \
+		echo "COMMIT_HASH=${COMMIT_HASH}" >> .env.production && \
+		echo "PATCH_ID=${PATCH_ID}" >> .env.production; \
+	fi && \
+	GATSBY_MANIFEST_PATH="${BUNDLE_PATH}" npm run build; \
+	cp -r "${REPO_DIR}/snooty/public" ${REPO_DIR};
+
+next-gen-stage: ## Host online for review
+	# stagel local jobs \
+	if [ -n "${PATCH_ID}" -a "${MUT_PREFIX}" = "${PROJECT}" ]; then \
+		mut-publish public ${BUCKET} --prefix="${COMMIT_HASH}/${PATCH_ID}/${MUT_PREFIX}" --stage ${ARGS}; \
+		echo "Hosted at ${URL}/${COMMIT_HASH}/${PATCH_ID}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
+	# stagel commit jobs and regular git push jobs\
+	else \
+		mut-publish public ${BUCKET} --prefix="${MUT_PREFIX}" --stage ${ARGS}; \
+		echo "Hosted at ${URL}/${MUT_PREFIX}/${USER}/${GIT_BRANCH}/"; \
+	fi
+
+get-build-dependencies:
+	echo "Published branches information stored in Atlas collection"
 
 fetch-submodule:
 	git submodule update --remote --init
 	rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source
-
-get-build-dependencies: fetch-submodule
-	echo "Published branches information stored in Atlas collection"

--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -73,4 +73,6 @@ get-build-dependencies:
 
 fetch-submodule:
 	git submodule update --remote --init
-	rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source
+	if [ -d "${REPO_DIR}/laravel-mongodb/docs" ]; then \
+		rsync -a --delete ${REPO_DIR}/laravel-mongodb/docs/ ${REPO_DIR}/source; \
+	fi


### PR DESCRIPTION
### Ticket

DOP-4237

### Notes

* Introduces a build step to fetch git submodule for `docs-laravel`.
* Copied over logic from other Makefiles that have custom build steps to ensure that the submodule can be fetched.
* [Example build log](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=queue&jobId=659f2488914de3d7f7644a95) - This build fails as expected due to the git submodule currently having no content for Snooty to parse.