### PR TITLE
bug. Fix Makefile separator

### DIFF
--- a/makefiles/Makefile.docs-pymongo
+++ b/makefiles/Makefile.docs-pymongo
@@ -16,6 +16,5 @@ SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
 
 include ~/shared.mk
 
-
 get-build-dependencies: 
-  echo "Published branches information stored in Atlas collection"
+	echo "Published branches information stored in Atlas collection"


### PR DESCRIPTION
Annoyingly my tab was not good enough! Also deleted an unused line break.

Error in log:

`reason: "Error: Command failed: make get-build-dependencies
Makefile:21: *** missing separator.  Stop.`