### PR TITLE
Removing lines for downloadBuildDependencies when building with makefiles

### DIFF
--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -531,8 +531,6 @@ export abstract class JobHandler {
     this._logger.save(this._currJob._id, 'Checked Commit');
     await this.pullRepo();
     this._logger.save(this._currJob._id, 'Pulled Repo');
-    await this.getAndDownloadBuildDependencies();
-    this._logger.save(this._currJob._id, 'Downloaded Build dependencies');
     this.prepBuildCommands();
     this._logger.save(this._currJob._id, 'Prepared Build commands');
     await this.prepNextGenBuild();


### PR DESCRIPTION
### Notes

Accidentally added downloading/getting build dependencies when building **with** Makefiles. This PR removes it.

[Build log building docs project](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=queue&jobId=65d637137111165982e1be7d)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
