### PR TITLE
DOP-4306-b remove branch from preprd

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - "main"
       - "integration"
-      - "DOP-4306"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Stories/Links:

[DOP-4306](https://jira.mongodb.org/browse/DOP-4306)

### Notes
Accidentally left DOP-4306 in `deploy-stg-ecs.yml` in a previous PR! This removes it!
### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
