### PR TITLE
DOP-4359: docs-languages Makefile

### DIFF
--- a/makefiles/Makefile.docs-languages
+++ b/makefiles/Makefile.docs-languages
@@ -1,0 +1,22 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+ifeq ($(STAGING_USERNAME),)
+	USER=$(shell whoami)
+else
+	USER=$(STAGING_USERNAME)
+endif
+
+PREFIX=languages
+PROJECT=languages
+MUT_PREFIX ?= $(PROJECT)
+
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	echo "Published branches information stored in Atlas collection"


### PR DESCRIPTION
### Stories/Links:

DOP-4359

### Notes

This adds a Makefile for the new repo: [docs-languages](https://github.com/mongodb/docs-languages)

This will hold the general Language landing page and all the specific language landing pages

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
