### PR TITLE
DOP-4359: add LanguagesBucket for s3

### DIFF
--- a/cdk-infra/utils/buckets.ts
+++ b/cdk-infra/utils/buckets.ts
@@ -15,6 +15,7 @@ export const docsBucketNames = [
   'docs-go',
   'docs-java',
   'docs-node',
+  'docs-languages',
 ] as const;
 
 interface CustomBucketProps {

--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -174,6 +174,19 @@ Resources:
           IndexDocument: index.html
           ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
 
+  LanguagesBucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      BucketName: ${self:custom.languagesBucketName}
+      WebsiteConfiguration:
+          IndexDocument: index.html
+          ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
+
   DocsBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -415,3 +428,33 @@ Resources:
             Action: 's3:PutObject'
             Resource:
               - Fn::Join: ['', [{ "Fn::GetAtt": ["CSharpBucket", "Arn" ] }, '/*']]
+
+  LanguagesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: LanguagesBucket
+      PolicyDocument:
+        Statement:
+          - Sid: PublicReadGetObject
+            Effect: Allow
+            Principal: "*"
+            Action:
+              - s3:GetObject
+            Resource:
+            - Fn::Join: ['', [{ "Fn::GetAtt": ["LanguagesBucket", "Arn" ] }, '/*']]
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::${aws:accountId}:role/docs-archive-job-${self:provider.stage}-batch
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
+            Resource:
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["LanguagesBucket", "Arn" ] }, '/*']]
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["LanguagesBucket", "Arn" ] }]]
+          - Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::${aws:accountId}:role/docs-deploy-job-${self:provider.stage}-batch
+            Action: 's3:PutObject'
+            Resource:
+              - Fn::Join: ['', [{ "Fn::GetAtt": ["LanguagesBucket", "Arn" ] }, '/*']]

--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -121,11 +121,9 @@ custom:
   cSharpBucketName: docs-csharp-${self:provider.stage}
   cSharpIntgrBucketName: docs-csharp-dev
   goBucketName: docs-go-${self:provider.stage}
-  goIntgrBucketName: docs-go-intgr
   javaBucketName: docs-java-${self:provider.stage}
-  javaIntgrBucketName: docs-java-intgr
   nodeBucketName: docs-node-${self:provider.stage}
-  nodeIntgrBucketName: docs-node-intgr
+  languagesBucketName: docs-languages-${self:provider.stage}
   jobCollection:  ${ssm:/env/${self:provider.stage}/docs/worker_pool/atlas/collections/job/queue}
   repoBranchesCollection: ${ssm:/env/${self:provider.stage}/docs/worker_pool/atlas/collections/repo}
   docsetsCollection: ${ssm:/env/${self:provider.stage}/docs/worker_pool/atlas/collections/docsets}


### PR DESCRIPTION
### Stories/Links:

DOP-4359

### Notes

This adds the necessary S3 Buckets for `docs-languages`

It also removes the intgr buckets that don't even exist in S3...?



### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
