### PR TITLE
DOP-4481 hotfix

### DIFF
--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - "main"
       - "integration"
-      - "DOP-4481-hotfix"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-stg-ecs.yml
+++ b/.github/workflows/deploy-stg-ecs.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - "main"
       - "integration"
+      - "DOP-4481-hotfix"
 concurrency:
   group: environment-stg-${{ github.ref }}
   cancel-in-progress: true

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -63,15 +63,11 @@ export class SlackConnector implements ISlackConnector {
     const inputMapping = {
       block_repo_option: 'repo_option',
       block_hash_option: 'hash_option',
-      block_deploy_option: 'deploy_option',
     };
 
     console.log(stateValues);
     // if deploy all was selected:
-    if (
-      stateValues['block_deploy_option'] &&
-      stateValues['block_deploy_option']?.deploy_option?.selected_option?.value == 'deploy_all'
-    ) {
+    if (stateValues['block_deploy_option']?.deploy_option?.selected_option?.value == 'deploy_all') {
       if (!isAdmin) {
         throw new Error('User is not an admin and therefore not entitled to deploy all repos');
       }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -66,8 +66,12 @@ export class SlackConnector implements ISlackConnector {
       block_deploy_option: 'deploy_option',
     };
 
+    console.log(stateValues);
     // if deploy all was selected:
-    if (stateValues['block_deploy_option']['deploy_option']?.selected_option?.value == 'deploy_all') {
+    if (
+      stateValues['block_deploy_option'] &&
+      stateValues['block_deploy_option']['deploy_option']?.selected_option?.value == 'deploy_all'
+    ) {
       if (!isAdmin) {
         throw new Error('User is not an admin and therefore not entitled to deploy all repos');
       }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -65,7 +65,6 @@ export class SlackConnector implements ISlackConnector {
       block_hash_option: 'hash_option',
     };
 
-    console.log(stateValues);
     // if deploy all was selected:
     if (stateValues['block_deploy_option']?.deploy_option?.selected_option?.value == 'deploy_all') {
       if (!isAdmin) {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -69,8 +69,8 @@ export class SlackConnector implements ISlackConnector {
     console.log(stateValues);
     // if deploy all was selected:
     if (
-      stateValues['block_deploy_option'] &&
-      stateValues['block_deploy_option']['deploy_option']?.selected_option?.value == 'deploy_all'
+      stateValues['block_deploy_option']?.deploy_option &&
+      stateValues['block_deploy_option']?.deploy_option?.selected_option?.value == 'deploy_all'
     ) {
       if (!isAdmin) {
         throw new Error('User is not an admin and therefore not entitled to deploy all repos');

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -69,7 +69,7 @@ export class SlackConnector implements ISlackConnector {
     console.log(stateValues);
     // if deploy all was selected:
     if (
-      stateValues['block_deploy_option']?.deploy_option &&
+      stateValues['block_deploy_option'] &&
       stateValues['block_deploy_option']?.deploy_option?.selected_option?.value == 'deploy_all'
     ) {
       if (!isAdmin) {


### PR DESCRIPTION
### Stories/Links:

This PR is a hotfix for an issue that prevents non-admin users from using the /deploy slack command to deploy repos following the release of [DOP-4481](https://jira.mongodb.org/browse/DOP-4481)

### Notes

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
