### PR TITLE
DOP-4571: migration script for bad repo branches

### DIFF
--- a/modules/persistence/DOP-4571.ts
+++ b/modules/persistence/DOP-4571.ts
@@ -1,0 +1,43 @@
+import * as dotenv from 'dotenv';
+// dotenv.config() should be invoked immediately, before any other imports, to ensure config is present
+dotenv.config();
+
+import { pool, teardown } from './src/services/connector';
+
+const migrate = async () => {
+  const db = await pool();
+  const collection = db.collection('repos_branches');
+  const repos = await collection.find().toArray();
+
+  for (let idx = 0; idx < repos.length; idx++) {
+    const problematicBranches: string[] = [];
+    const repo = repos[idx];
+    // if (repo.branches.length === 1) {
+    // 	continue;
+    // }
+    repo.branches.forEach((branch) => {
+      if (
+        !branch.publishOriginalBranchName &&
+        branch.urlSlug === branch.gitBranchName &&
+        !branch.urlAliases?.includes(branch.urlSlug)
+      ) {
+        problematicBranches.push(branch.gitBranchName);
+        branch.publishOriginalBranch = true;
+      }
+    });
+    if (problematicBranches.length) {
+      console.log(`updating repo with id ${repo._id} (${repo.repoName}) for branches ${problematicBranches}`);
+      await collection.updateOne({ _id: repo._id }, repo);
+    }
+  }
+
+  await teardown();
+};
+
+migrate()
+  .then(() => {
+    console.log('finished');
+  })
+  .catch((e) => {
+    console.error(e);
+  });

--- a/modules/persistence/DOP-4571.ts
+++ b/modules/persistence/DOP-4571.ts
@@ -22,12 +22,12 @@ const migrate = async () => {
         !branch.urlAliases?.includes(branch.urlSlug)
       ) {
         problematicBranches.push(branch.gitBranchName);
-        branch.publishOriginalBranch = true;
+        branch.publishOriginalBranchName = true;
       }
     });
     if (problematicBranches.length) {
       console.log(`updating repo with id ${repo._id} (${repo.repoName}) for branches ${problematicBranches}`);
-      await collection.updateOne({ _id: repo._id }, repo);
+      await collection.updateOne({ _id: repo._id }, { $set: { branches: repo.branches } });
     }
   }
 

--- a/modules/persistence/src/services/connector/index.ts
+++ b/modules/persistence/src/services/connector/index.ts
@@ -8,7 +8,7 @@ import { ObjectId, Db, Document } from 'mongodb';
 import { db as poolDb } from './pool';
 
 // We should only ever have one client active at a time.
-const atlasURL = `mongodb+srv://${process.env.MONGO_ATLAS_USERNAME}:${process.env.MONGO_ATLAS_PASSWORD}@${process.env.MONGO_ATLAS_HOST}/?retryWrites=true&w=majority&maxPoolSize=20`;
+const atlasURL = `mongodb://${process.env.MONGO_ATLAS_HOST}`;
 const client = new mongodb.MongoClient(atlasURL);
 
 export const teardown = async () => {

--- a/modules/persistence/tsconfig.json
+++ b/modules/persistence/tsconfig.json
@@ -9,6 +9,6 @@
     "baseUrl": "./",
     "types": ["adm-zip"]
   },
-  "include": ["src/**/*.ts", "index.ts"],
+  "include": ["src/**/*.ts", "index.ts", "DOP-4571.ts"],
   "exclude": ["node_modules", "tests/**/*.ts"]
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4571

### Notes
- simple migration logic to update `pool.repos_branches` for bad branch values
- set publishOriginalBranchName = true for each branch that meets the criteria:
```
publishOriginalBranchName is not true
urlSlug === gitBranchName
urlAliases doesn't contain urlSlug
```
- concern that `master` branches will be pushed to `mongodb.com/docs/{prefix}/master` with this change, but [this line seems safe](https://github.com/mongodb/docs-worker-pool/blob/32a6dfb0c5666fc26557ab2261def0fec248fc50/api/controllers/v2/slack.ts#L163)
