### PR TITLE
DOP-4701: Preserve stdout in ShellCommandExecutor

### DIFF
--- a/src/services/commandExecutor.ts
+++ b/src/services/commandExecutor.ts
@@ -65,7 +65,7 @@ export class ShellCommandExecutor implements ICommandExecutor {
       resp.status = CommandExecutorResponseStatus.success;
       return resp;
     } catch (error) {
-      resp.output = '';
+      resp.output = (error.stdout || '').trim();
       resp.error = error;
       resp.status = CommandExecutorResponseStatus.failed;
     }

--- a/tests/unit/services/shellCommandExecutor.test.ts
+++ b/tests/unit/services/shellCommandExecutor.test.ts
@@ -1,6 +1,5 @@
 import { ShellCommandExecutor } from '../../../src/services/commandExecutor';
 import cp from 'child_process';
-jest.mock('child_process');
 
 describe('ShellCommandExecutor Tests', () => {
   let commandExecutor: ShellCommandExecutor;
@@ -18,15 +17,26 @@ describe('ShellCommandExecutor Tests', () => {
   });
 
   describe('ShellCommandExecutor Tests', () => {
+    test('ShellCommandExecutor returns correct output on success', async () => {
+      const command = ["echo 'stdout output'", "echo 'stderr output' >&2"];
+      const resp = await commandExecutor.execute(command);
+
+      expect(resp.error.toString()).toStrictEqual('stderr output\n');
+      expect(resp.output).toBe('stdout output');
+      expect(resp.status).toBe('success');
+    });
+
     test('ShellCommandExecutor properly throws on system level error', async () => {
-      cp.exec.mockImplementation((command, options, callback) => {
-        callback(Error('Test error'), { stdErr: 'invalid command', stdout: 'test_repo_project_snooty_name' });
-      });
-      const resp = await commandExecutor.execute([]);
-      expect(resp.error).not.toBe(undefined);
-      expect(resp.output).toBe('');
+      const command = ["echo 'stdout output'", "echo 'stderr output' >&2", 'exit 1'];
+      const resp = await commandExecutor.execute(command);
+
+      // This is a strange interface, but I'm just here to fix a bug, not change the interface.
+      // The type of resp.error can be either a string or an Error instance.
+      expect(resp.error.toString()).toStrictEqual(
+        "Error: Command failed: echo 'stdout output' && echo 'stderr output' >&2 && exit 1\nstderr output\n"
+      );
+      expect(resp.output).toBe('stdout output');
       expect(resp.status).toBe('failed');
-      expect(cp.exec).toBeCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
### Stories/Links:

[DOP-4701](https://jira.mongodb.org/browse/DOP-4701)

### Notes

The actual fix is the one line change in `commandExecutor.ts`.

The annoying part was making the test work:
* The existing test incorrectly mocked the `child_process.exec()` interface.
* According to the node docs, the exception raised by `util.promisify(child_process.exec())` will always have a `stdout` property. But just in case the exception get raised by something *else* in the try block, it'll fall back to returning `''` as in the current behavior.
* `util.promisify(child_process.exec)` has a custom promisifier (`child_process.exec[util.promisify.custom]`) that considerably changes the interface, but that jest loses when you call `jest.mock('child_process')`, and because of jest magic tomfoolery, I couldn't find any tidy way to *restore* that custom hook, which is needed to actually make the interface behave correctly.

  So I thought, you know what? Why mock? What value do we get by mocking `child_process.exec` besides introducing surface areas for bugs?
  
  So this PR just executes `commandExecutor.execute(["echo 'stdout output'", "echo 'stderr output' >&2", 'exit 1'])`, which gives us everything we need to make sure ShellCommandExecutor actually works, using only shell builtins that we already require.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
