### PR TITLE
DOP-4589: Create bucket-level redirects for several versions

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -13,11 +13,23 @@ Resources:
           ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
           RoutingRules:
             - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/stable
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/manual
+            - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/master
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/upcoming
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/manual
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/current
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/manual
             - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/v1.3.0
               RedirectRule:
@@ -131,25 +143,31 @@ Resources:
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self.custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/stable
-            - RoutingRuleCondition:
-                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/v1.0
-              RedirectRule:
-                Protocol: "https"
-                HostName: ${self.custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/stable
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/current
             - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/v1
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self.custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/stable
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/current
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/stable
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/kubernetes-operator/current
             - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/mongocli/v0.
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self.custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/mongocli/stable
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/mongocli/current
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/mongocli/stable
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/mongocli/current
             - RoutingRuleCondition:
                 KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/spark-connector/v1.1
               RedirectRule:
@@ -168,6 +186,24 @@ Resources:
                 Protocol: "https"
                 HostName: ${self.custom.site.host.${self:provider.stage}}
                 ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/spark-connector/current
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/ruby-driver/master
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/ruby-driver/upcoming
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/compass/beta
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/compass/current
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/compass/upcoming
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/compass/current
   DocAtlasBucket:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -180,6 +216,18 @@ Resources:
       WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
+          - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/stable
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/current
+          - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/atlas-operator/stable
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self.custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/atlas-operator/current
   CloudManagerBucket:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -270,6 +318,14 @@ Resources:
       WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: ${self:custom.site.errorDoc.${self:provider.stage}, null}
+          RoutingRules:
+            - RoutingRuleCondition:
+                  KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/languages/scala/driver/master
+                RedirectRule:
+                  Protocol: "https"
+                  HostName: ${self.custom.site.host.${self:provider.stage}}
+                  ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/languages/scala/driver/upcoming
+
 
   DocsBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
### Stories/Links:

DOP-4589

[Relevant Spreadsheet](https://docs.google.com/spreadsheets/d/1UKnNXw39IATCdDVCJND815ORqE-BB_WFA2Mi_VM-420/edit#gid=0)

### Notes

- changed `stable` to `current` for redirects added in [Allison's PR](https://github.com/mongodb/docs-worker-pool/pull/1041)
- deleted k8s operator prefix `/v1.0` redirect since this is captured by `v1`
- left off mongoid and spark-connector `master` -> `upcoming` redirects since these seem to already redirect? LMK if I should explicitly add them

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
