### PR TITLE
DOP-4669: add env var for enabling dark mode

### DIFF
--- a/cdk-infra/lib/constructs/worker/worker-env-construct.ts
+++ b/cdk-infra/lib/constructs/worker/worker-env-construct.ts
@@ -64,6 +64,7 @@ export class WorkerEnvConstruct extends Construct {
     const docsetsCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/docsets`);
     const jobCollection = StringParameter.valueFromLookup(this, `${ssmPrefix}/atlas/collections/job/queue`);
     const gatsbyMarianUrl = StringParameter.valueFromLookup(this, `${ssmPrefix}/frontend/marian_url`);
+    const gatsbyEnableDarkMode = StringParameter.valueFromLookup(this, `${ssmPrefix}/frontend/enable_dark_mode`);
 
     const dbPassword = secureStrings['MONGO_ATLAS_PASSWORD'];
     this.environment = {
@@ -101,6 +102,7 @@ export class WorkerEnvConstruct extends Construct {
       GATSBY_HIDE_UNIFIED_FOOTER_LOCALE: gatsbyHideUnifiedFooterLocale,
       GATSBY_MARIAN_URL: gatsbyMarianUrl,
       IS_FEATURE_BRANCH: getIsFeatureBranch(),
+      GATSBY_ENABLE_DARK_MODE: gatsbyEnableDarkMode,
     };
   }
 }

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -34,5 +34,6 @@
   "cdnClientID": "CDN_CLIENT_ID",
   "cdnClientSecret": "CDN_CLIENT_SECRET",
   "cdnInvalidatorServiceURL": "CDN_INVALIDATOR_SERVICE_URL",
-  "searchIndexBucket": "SEARCH_INDEX_BUCKET"
+  "searchIndexBucket": "SEARCH_INDEX_BUCKET",
+  "gatsbyEnableDarkMode": "GATSBY_ENABLE_DARK_MODE"
 }

--- a/infrastructure/ecs-main/ecs_service.yml
+++ b/infrastructure/ecs-main/ecs_service.yml
@@ -68,6 +68,8 @@ Resources:
               Value: ${self:custom.featureFlagSearchUI}
             - Name: GATSBY_MARIAN_URL
               Value: ${self:custom.gatsbyMarianURL}
+            - Name: GATSBY_ENABLE_DARK_MODE
+              Value: ${self:custom.gatsbyEnableDarkMode}
             - Name: GATSBY_HIDE_UNIFIED_FOOTER_LOCALE
               Value: ${self:custom.gatsbyHideUnifiedFooterLocale}
             - Name: FASTLY_MAIN_TOKEN

--- a/src/commands/src/helpers/dependency-helpers.ts
+++ b/src/commands/src/helpers/dependency-helpers.ts
@@ -36,7 +36,8 @@ async function createEnvProdFile({
       GATSBY_MARIAN_URL=${process.env.GATSBY_MARIAN_URL}
       PATH_PREFIX=${prefix}
       ${patchId ? `PATCH_ID=${patchId}` : ''}
-      ${commitHash ? `COMMIT_HASH=${commitHash}` : ''}`,
+      ${commitHash ? `COMMIT_HASH=${commitHash}` : ''}
+      GATSBY_ENABLE_DARK_MODE=${process.env.GATSBY_ENABLE_DARK_MODE}`,
       'utf8'
     );
   } catch (e) {

--- a/src/job/jobHandler.ts
+++ b/src/job/jobHandler.ts
@@ -413,6 +413,7 @@ export abstract class JobHandler {
       GATSBY_TEST_SEARCH_UI: this._config.get<string>('featureFlagSearchUI'),
       GATSBY_HIDE_UNIFIED_FOOTER_LOCALE: this._config.get<string>('gatsbyHideUnifiedFooterLocale'),
       GATSBY_MARIAN_URL: this._config.get<string>('gatsbyMarianURL'),
+      GATSBY_ENABLE_DARK_MODE: this._config.get<string>('gatsbyEnableDarkMode'),
     };
 
     for (const [envName, envValue] of Object.entries(snootyFrontEndVars)) {

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -176,7 +176,7 @@ export class TestDataProvider {
   }
 
   static getEnvVarsWithPathPrefixWithFlags(job: Job): string {
-    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\nGATSBY_MARIAN_URL=test-url\n`;
+    return `GATSBY_PARSER_USER=TestUser\nGATSBY_PARSER_BRANCH=${job.payload.branchName}\nPATH_PREFIX=${job.payload.pathPrefix}\nGATSBY_BASE_URL=test\nPREVIEW_BUILD_ENABLED=false\nGATSBY_TEST_SEARCH_UI=false\nGATSBY_HIDE_UNIFIED_FOOTER_LOCALE=true\nGATSBY_MARIAN_URL=test-url\nGATSBY_ENABLE_DARK_MODE=true\n`;
   }
 
   static getPathPrefixCases(): Array<any> {

--- a/tests/utils/jobHandlerTestHelper.ts
+++ b/tests/utils/jobHandlerTestHelper.ts
@@ -166,6 +166,7 @@ export class JobHandlerTestHelper {
       .calledWith(`repos/${this.job.payload.repoName}/worker.sh`)
       .mockReturnValue(nextGenEntry);
     this.config.get.calledWith('GATSBY_PARSER_USER').mockReturnValue('TestUser');
+    this.config.get.calledWith('gatsbyEnableDarkMode').mockReturnValue('true');
     this.jobCommandExecutor.execute.mockResolvedValue({ status: 'success', output: 'Great work', error: null });
   }
 }


### PR DESCRIPTION
### Stories/Links:

DOP-4669

This PR adds logic to fetch AWS SM Param Store variables and use it to populate environment variables in the autobuilder + snooty front end

### Notes
- These key/values have been added to the param store manually in S3, with `dotcomprd` and `prd` values being false as [described in ticket](https://jira.mongodb.org/browse/DOP-4669?focusedCommentId=6373200&focusedId=6373200&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6373200) 

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
