### PR TITLE
DOP-4669: follow up - add custom env var to sls

### DIFF
--- a/infrastructure/ecs-main/serverless.yml
+++ b/infrastructure/ecs-main/serverless.yml
@@ -107,6 +107,7 @@ custom:
   gatsbyTestEmbedVersions: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/embedded_versions}
   gatsbyHideUnifiedFooterLocale: ${ssm:/env/${self:provider.stage}/docs/worker_pool/flag/hide_locale}
   gatsbyMarianURL: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/marian_url}
+  gatsbyEnableDarkMode: ${ssm:/env/${self:provider.stage}/docs/worker_pool/frontend/enable_dark_mode}
   fastlyMainToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/token}
   fastlyMainServiceId: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/main/service_id}
   fastlyCloudManagerToken: ${ssm:/env/${self:provider.stage}/docs/worker_pool/fastly/docs/cloudmanager/token}


### PR DESCRIPTION
### Stories/Links:

DOP-4669

### Notes
- Attempt to fix [this failure to deploy-stg action](https://github.com/mongodb/docs-worker-pool/actions/runs/9270176679/job/25502560914). Seems like the error is complaining that the `self.custom.gatsbyEnableDarkMode` was not defined, added the definition

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
