### PR TITLE
DOP-4704: Ignore errors when rsyncing mongo-ruby-driver

### DIFF
--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -59,8 +59,8 @@ get-build-dependencies: fetch-submodule
 
 fetch-submodule:
 	git submodule update --remote --init
-	rsync -a --delete ${REPO_DIR}/mongo-ruby-driver/docs/ ${REPO_DIR}/source
-	rsync -a --delete ${REPO_DIR}/bson-ruby/docs/tutorials/bson.txt ${REPO_DIR}/source/tutorials/bson.txt
+	-rsync -a --delete ${REPO_DIR}/mongo-ruby-driver/docs/ ${REPO_DIR}/source
+	-rsync -a --delete ${REPO_DIR}/bson-ruby/docs/tutorials/bson.txt ${REPO_DIR}/source/tutorials/bson.txt
 
 next-gen-stage: ## Host online for review
 	# stagel local jobs \


### PR DESCRIPTION
This is an intermediate step to allow building docs-ruby without that submodule.

This line should go away entirely once the transition to not using a submodule is complete.

### Stories/Links:

DOP-4704

### Notes

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
