### PR TITLE
DOP-4744: Add Makefile for docs-mongoid-railsmdb

### DIFF
--- a/makefiles/Makefile.docs-mongoid-railsmdb
+++ b/makefiles/Makefile.docs-mongoid-railsmdb
@@ -1,0 +1,21 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+ifeq ($(STAGING_USERNAME),)
+	USER=$(shell whoami)
+else
+	USER=$(STAGING_USERNAME)
+endif
+
+PROJECT=mongoid-railsmdb
+MUT_PREFIX ?= $(PROJECT)
+
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	echo "Published branches information stored in Atlas collection"


### PR DESCRIPTION
### Stories/Links:

DOP-4744

### Notes

* Adds Makefile for new repo. No special dependencies are needed.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README
