### PR TITLE
DOP-4758: remove flag for rstspec

### DIFF
--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -38,14 +38,14 @@ STABLE_BRANCH=`grep 'manual' build/docs-tools/data/manual-published-branches.yam
 next-gen-parse: examples
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-atlas-cli
+++ b/makefiles/Makefile.docs-atlas-cli
@@ -22,14 +22,14 @@ include ~/shared.mk
 next-gen-parse: fetch-submodule
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-atlas-operator
+++ b/makefiles/Makefile.docs-atlas-operator
@@ -22,14 +22,14 @@ include ~/shared.mk
 next-gen-parse: fetch-submodule
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-landing
+++ b/makefiles/Makefile.docs-landing
@@ -33,14 +33,14 @@ get-build-dependencies:
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen
 	if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-laravel
+++ b/makefiles/Makefile.docs-laravel
@@ -22,14 +22,14 @@ include ~/shared.mk
 next-gen-parse: fetch-submodule
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-mongocli
+++ b/makefiles/Makefile.docs-mongocli
@@ -22,14 +22,14 @@ include ~/shared.mk
 next-gen-parse: fetch-submodule
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-mongodb-internal
+++ b/makefiles/Makefile.docs-mongodb-internal
@@ -26,14 +26,14 @@ get-build-dependencies:
 next-gen-parse: examples
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-mongodb-internal-base
+++ b/makefiles/Makefile.docs-mongodb-internal-base
@@ -25,14 +25,14 @@ get-build-dependencies:
 next-gen-parse: examples
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-mongoid
+++ b/makefiles/Makefile.docs-mongoid
@@ -18,14 +18,14 @@ include ~/shared.mk
 next-gen-parse: get-build-dependencies
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -18,14 +18,14 @@ include ~/shared.mk
 next-gen-parse: get-build-dependencies
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/Makefile.docs-ruby
+++ b/makefiles/Makefile.docs-ruby
@@ -18,14 +18,14 @@ include ~/shared.mk
 next-gen-parse: get-build-dependencies
 	# snooty parse -- separated from front-end to support index gen
 	@if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -15,11 +15,11 @@ PATCH_CLAUSE=$(shell if [ ! -z "${PATCH_ID}" ]; then echo --patch "${PATCH_ID}";
 
 BUNDLE_PATH=${REPO_DIR}/bundle.zip
 ifdef SNOOTY_PARSER_VERSION
-PARSER_VERSION := $(SNOOTY_PARSER_VERSION)
+PARSER_VERSION := v$(SNOOTY_PARSER_VERSION)
 else
 PARSER_VERSION := main
 endif
-RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/v${PARSER_VERSION}/snooty/rstspec.toml
+RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/${PARSER_VERSION}/snooty/rstspec.toml
 
 ifeq ($(SNOOTY_INTEGRATION),true)
 	BUCKET_FLAG=-b ${INTEGRATION_SEARCH_BUCKET}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -14,13 +14,6 @@ PATCH_ID=$(shell if test -f "${PATCH_FILE}"; then git patch-id < ${PATCH_FILE} |
 PATCH_CLAUSE=$(shell if [ ! -z "${PATCH_ID}" ]; then echo --patch "${PATCH_ID}"; fi)
 
 BUNDLE_PATH=${REPO_DIR}/bundle.zip
-ifdef SNOOTY_PARSER_VERSION
-PARSER_VERSION := v$(SNOOTY_PARSER_VERSION)
-else
-PARSER_VERSION := main
-endif
-RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/${PARSER_VERSION}/snooty/rstspec.toml
-
 ifeq ($(SNOOTY_INTEGRATION),true)
 	BUCKET_FLAG=-b ${INTEGRATION_SEARCH_BUCKET}
 endif
@@ -42,14 +35,14 @@ ifndef PUSHLESS_DEPLOY_SHARED_DISABLED
 next-gen-parse:
 	# snooty parse -- separated from front-end to support index gen
 	if [ -n "${PATCH_ID}" ]; then \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" --commit "${COMMIT_HASH}" ${PATCH_CLAUSE} ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \
 			exit 0; \
 		fi \
 	else \
-		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${RSTSPEC_FLAG} ${NO_CACHING}; \
+		snooty build "${REPO_DIR}" --output "${BUNDLE_PATH}" ${NO_CACHING}; \
 		if [ $$? -eq 1 ]; then \
 			exit 1; \
 		else \

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -14,7 +14,12 @@ PATCH_ID=$(shell if test -f "${PATCH_FILE}"; then git patch-id < ${PATCH_FILE} |
 PATCH_CLAUSE=$(shell if [ ! -z "${PATCH_ID}" ]; then echo --patch "${PATCH_ID}"; fi)
 
 BUNDLE_PATH=${REPO_DIR}/bundle.zip
-RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/latest/snooty/rstspec.toml
+ifdef SNOOTY_PARSER_VERSION
+PARSER_VERSION := $(SNOOTY_PARSER_VERSION)
+else
+PARSER_VERSION := main
+endif
+RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/${PARSER_VERSION}/snooty/rstspec.toml
 
 ifeq ($(SNOOTY_INTEGRATION),true)
 	BUCKET_FLAG=-b ${INTEGRATION_SEARCH_BUCKET}

--- a/makefiles/shared.mk
+++ b/makefiles/shared.mk
@@ -19,7 +19,7 @@ PARSER_VERSION := $(SNOOTY_PARSER_VERSION)
 else
 PARSER_VERSION := main
 endif
-RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/${PARSER_VERSION}/snooty/rstspec.toml
+RSTSPEC_FLAG=--rstspec=https://raw.githubusercontent.com/mongodb/snooty-parser/v${PARSER_VERSION}/snooty/rstspec.toml
 
 ifeq ($(SNOOTY_INTEGRATION),true)
 	BUCKET_FLAG=-b ${INTEGRATION_SEARCH_BUCKET}


### PR DESCRIPTION
### Stories/Links:

DOP-4758

### Notes
- Makefiles should point at the env var ([specified in Dockerfile](https://github.com/mongodb/docs-worker-pool/pull/1057/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R25)) or fallback to the main branch for latest rstspec

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
