### PR TITLE
:wrench: DOP-4776 adds the new makefile

### DIFF
--- a/makefiles/Makefile.docs-kotlin-sync
+++ b/makefiles/Makefile.docs-kotlin-sync
@@ -18,4 +18,4 @@ include ~/shared.mk
 
 
 get-build-dependencies: 
-	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml
+	echo "Published branches information stored in Atlas collection"

--- a/makefiles/Makefile.docs-kotlin-sync
+++ b/makefiles/Makefile.docs-kotlin-sync
@@ -1,0 +1,21 @@
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+ifeq ($(STAGING_USERNAME),)
+	USER=$(shell whoami)
+else
+	USER=$(STAGING_USERNAME)
+endif
+
+PROJECT=kotlin-sync-driver
+MUT_PREFIX ?= $(PROJECT)
+
+REPO_DIR=$(shell pwd)
+
+SNOOTY_DB_USR = $(shell printenv MONGO_ATLAS_USERNAME)
+SNOOTY_DB_PWD = $(shell printenv MONGO_ATLAS_PASSWORD)
+
+include ~/shared.mk
+
+
+get-build-dependencies: 
+	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-node.yaml > ${REPO_DIR}/published-branches.yaml


### PR DESCRIPTION
### Stories/Links:

DOP-4776

### Notes

Adds the new makefile for `kotlin-sync`

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
