### PR TITLE
DOP-4809: Permit mongoid submodule setup to fail

### DIFF
--- a/makefiles/Makefile.docs-mongoid
+++ b/makefiles/Makefile.docs-mongoid
@@ -58,8 +58,8 @@ get-build-dependencies: fetch-submodule
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-php-library.yaml > ${REPO_DIR}/published-branches.yaml
 
 fetch-submodule:
-	git submodule update --remote --init
-	rsync -a --delete ${REPO_DIR}/mongoid/docs/ ${REPO_DIR}/source
+	-git submodule update --remote --init
+	-rsync -a --delete ${REPO_DIR}/mongoid/docs/ ${REPO_DIR}/source
 
 next-gen-stage: ## Host online for review
 	# stagel local jobs \


### PR DESCRIPTION
This is required for removing the submodule configuration from mongodb/docs-mongoid.

### Stories/Links:

DOP-4809

### Notes

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
