### PR TITLE
DOP-4884: Permit docs-php-library submodule setup to fail

### DIFF
--- a/makefiles/Makefile.docs-php-library
+++ b/makefiles/Makefile.docs-php-library
@@ -57,8 +57,8 @@ get-build-dependencies: fetch-submodule
 	@curl https://raw.githubusercontent.com/mongodb/docs-worker-pool/meta/publishedbranches/docs-php-library.yaml > ${REPO_DIR}/published-branches.yaml
 
 fetch-submodule:
-	git submodule update --remote --init
-	rsync -a --delete ${REPO_DIR}/mongo-php-library/docs/ ${REPO_DIR}/source
+	-git submodule update --remote --init
+	-rsync -a --delete ${REPO_DIR}/mongo-php-library/docs/ ${REPO_DIR}/source
 
 next-gen-stage: ## Host online for review
 	# stagel local jobs \


### PR DESCRIPTION
### Stories/Links:

DOP-4884

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
