### PR TITLE
[DOP-4876]: Add deprecation warning message to Autobuilder staging builds

### DIFF
--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -118,7 +118,7 @@ function prepProgressMessage(
   const msg = `Your Job (<${jobUrl}${jobId}|${jobTitle}>) `;
   switch (status) {
     case 'inQueue':
-      return msg + `has successfully been added to the ' + env + ' queue. ${deprecationWarning}`;
+      return msg + `has successfully been added to the ${env} queue. ${deprecationWarning}`;
     case 'inProgress':
       return msg + 'is now being processed.';
     case 'completed':

--- a/api/controllers/v2/jobs.ts
+++ b/api/controllers/v2/jobs.ts
@@ -110,11 +110,15 @@ function prepProgressMessage(
   status: string,
   errorReason: string
 ): string {
-  const msg = `Your Job (<${jobUrl}${jobId}|${jobTitle}>) `;
   const env = c.get<string>('env');
+  const deprecationWarning =
+    env === 'prd'
+      ? 'The Autobuilder for staging will be deprecated by Sept. 30th. Please reach out to #ask-docs-platform on questions on how to migrate to Netlify for staging builds.'
+      : '';
+  const msg = `Your Job (<${jobUrl}${jobId}|${jobTitle}>) `;
   switch (status) {
     case 'inQueue':
-      return msg + 'has successfully been added to the ' + env + ' queue.';
+      return msg + `has successfully been added to the ' + env + ' queue. ${deprecationWarning}`;
     case 'inProgress':
       return msg + 'is now being processed.';
     case 'completed':


### PR DESCRIPTION
### Stories/Links:

[DOP-4876](https://jira.mongodb.org/browse/DOP-4876)

### Notes

Provides a deprecation notice for writers using the Autobuilder for staging builds (`prd`)
### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
