### PR TITLE
DOP-5065: add redirect rule for compass - master

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -288,6 +288,12 @@ Resources:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}
                 ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/compass/current
+            - RoutingRuleCondition:
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/compass/master/
+              RedirectRule:
+                Protocol: "https"
+                HostName: ${self:custom.site.host.${self:provider.stage}}
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/compass/current/
   DocAtlasBucket:
     Type: "AWS::S3::Bucket"
     Properties:


### PR DESCRIPTION
### Stories/Links:

DOP-5065

### Notes
- We have a maximum of 50 redirect rules. We are approaching this (47 at this bucket) and will need to resort to object redirects at 50.
- From [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-routingrulecondition.html), it looks like a trailing slash is preferred, but wondering why we don't have trailing slashes for redirect prefix rules. I've included them in the change, but can make this change bigger to the existing redirects. This has caused issues before (ie. [bad redirects from bi-connector versions](https://jira.mongodb.org/browse/DOP-5051))

Tested in staging env:
https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/compass/master
With [redirect rules](https://us-east-2.console.aws.amazon.com/s3/bucket/docs-mongodb-org-dotcomstg/property/website/edit?region=us-east-2&bucketType=general) showing:
```
{
        "Condition": {
            "KeyPrefixEquals": "docs-qa/compass/master/"
        },
        "Redirect": {
            "HostName": "mongodbcom-cdn.website.staging.corp.mongodb.com",
            "Protocol": "https",
            "ReplaceKeyPrefixWith": "docs-qa/compass/current/"
        }
    }
```

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README
