### PR TITLE
Update V2.1 Bi-connector redirect

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -103,7 +103,7 @@ Resources:
                 HostName: ${self:custom.site.host.${self:provider.stage}}
                 ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/bi-connector/current
             - RoutingRuleCondition:
-                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/bi-connector/v2.1
+                KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/bi-connector/v2.1/
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}


### PR DESCRIPTION
### Stories/Links:

[DOP-5051](https://jira.mongodb.org/browse/DOP-5051)

### Notes

The bucket-level redirect for bi-connector v2.1 is accidentally capturing paths for other versions, leading to bad redirects such as docs/bi-connector/v2.10-> docs/bi-connector/current0 and docs/bi-connector/v2.11-> docs/bi-connector/current11
This PR adds a trailing slash so that the redirect no longer captures paths for other versions on accident.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
