### PR TITLE
Dop 5395

### DIFF
--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -299,13 +299,13 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
 
 export const insertAndUpdatePages = async (buildId: ObjectId, zip: AdmZip, githubUser: string) => {
   try {
-    const pages = pagesFromZip(zip, githubUser);
-
     // TEMPORARY FIX FOR NETLIFY BUILDS
     // TODO: DOP-5405 remove parser user from page id altogether
-    for (const page of pages) {
+
+    const pages = pagesFromZip(zip, githubUser).map((page: Page) => {
       page.page_id = page.page_id.replace('buildbot', 'docsworker-xlarge');
-    }
+      return page;
+    });
 
     const ops: PromiseLike<any>[] = [insert(pages, COLLECTION_NAME, buildId, true)];
 

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -269,11 +269,7 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   try {
     // TEMPORARY FIX FOR NETLIFY BUILDS
     // TODO: DOP-5405 remove parser user from page id
-    const pageIdArr = pages[0].page_id.split('/').slice(0, 3);
-    if (pageIdArr[1] === 'buildbot') {
-      pageIdArr[1] = 'docsworker-xlarge';
-    }
-    const pageIdPrefix = pageIdArr.join('/');
+    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/').replace('buildbot', 'docsworker-xlarge');
 
     // Find all pages that share the same project name + branch. Expects page IDs
     // to include these two properties after parse

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -267,12 +267,9 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   console.time(timerLabel);
 
   try {
-    // TEMPORARY FIX FOR NETLIFY BUILDS
-    // TODO: DOP-5405 remove parser user from page id
-    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/').replace('buildbot', 'docsworker-xlarge');
-
     // Find all pages that share the same project name + branch. Expects page IDs
     // to include these two properties after parse
+    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/');
     const previousPagesCursor = await findPrevPageDocs(pageIdPrefix, collection, githubUser);
     const { mapping: prevPageDocsMapping, pageIds: prevPageIds } = await createPageAstMapping(previousPagesCursor);
 

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -267,14 +267,16 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   console.time(timerLabel);
 
   try {
-    // Find all pages that share the same project name + branch. Expects page IDs
-    // to include these two properties after parse
+    // TEMPORARY FIX FOR NETLIFY BUILDS
+    // TODO: DOP-5405 remove parser user from page id
     const pageIdArr = pages[0].page_id.split('/').slice(0, 3);
     if (pageIdArr[1] === 'buildbot') {
       pageIdArr[1] = 'docsworker-xlarge';
     }
     const pageIdPrefix = pageIdArr.join('/');
 
+    // Find all pages that share the same project name + branch. Expects page IDs
+    // to include these two properties after parse
     const previousPagesCursor = await findPrevPageDocs(pageIdPrefix, collection, githubUser);
     const { mapping: prevPageDocsMapping, pageIds: prevPageIds } = await createPageAstMapping(previousPagesCursor);
 

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -269,7 +269,12 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   try {
     // Find all pages that share the same project name + branch. Expects page IDs
     // to include these two properties after parse
-    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/');
+    const pageIdArr = pages[0].page_id.split('/').slice(0, 3);
+    if (pageIdArr[1] === 'buildbot') {
+      pageIdArr[1] = 'docsworker-xlarge';
+    }
+    const pageIdPrefix = pageIdArr.join('/');
+
     const previousPagesCursor = await findPrevPageDocs(pageIdPrefix, collection, githubUser);
     const { mapping: prevPageDocsMapping, pageIds: prevPageIds } = await createPageAstMapping(previousPagesCursor);
 

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -267,9 +267,7 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   console.time(timerLabel);
 
   try {
-    // TEMPORARY FIX FOR NETLIFY BUILDS
-    // TODO: DOP-5405 remove parser user from page id
-    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/').replace('buildbot', 'docsworker-xlarge');
+    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/');
 
     // Find all pages that share the same project name + branch. Expects page IDs
     // to include these two properties after parse
@@ -303,6 +301,13 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
 export const insertAndUpdatePages = async (buildId: ObjectId, zip: AdmZip, githubUser: string) => {
   try {
     const pages = pagesFromZip(zip, githubUser);
+
+    // TEMPORARY FIX FOR NETLIFY BUILDS
+    // TODO: DOP-5405 remove parser user from page id altogether
+    for (const page of pages) {
+      page.page_id = page.page_id.replace('buildbot', 'docsworker-xlarge');
+    }
+
     const ops: PromiseLike<any>[] = [insert(pages, COLLECTION_NAME, buildId, true)];
 
     const featureEnabled = process.env.FEATURE_FLAG_UPDATE_PAGES;

--- a/modules/persistence/src/services/pages/index.ts
+++ b/modules/persistence/src/services/pages/index.ts
@@ -267,10 +267,9 @@ const updatePages = async (pages: Page[], collection: string, githubUser: string
   console.time(timerLabel);
 
   try {
-    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/');
-
     // Find all pages that share the same project name + branch. Expects page IDs
     // to include these two properties after parse
+    const pageIdPrefix = pages[0].page_id.split('/').slice(0, 3).join('/');
     const previousPagesCursor = await findPrevPageDocs(pageIdPrefix, collection, githubUser);
     const { mapping: prevPageDocsMapping, pageIds: prevPageIds } = await createPageAstMapping(previousPagesCursor);
 


### PR DESCRIPTION
[DOP-5395](https://jira.mongodb.org/browse/DOP-5395)
Persistence Module not updating updated_documents collection

Notes
Hotfix so that persistence module updates and uploads all documents with 'docsworker-xlarge' as the parser user. Should be undone in [DOP-5405](https://jira.mongodb.org/browse/DOP-5405).

Previous PRs were insufficient; need to replace parser user in the page_id of every page near the entry point of the persistence module and do it correctly..

Example: { page_id:
"compass/docsworker-xlarge/master/query-with-natural-language" }
### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
