### PR TITLE
DOP-5450: Change atlas operator routing `/atlas-operator` -> `/operator`

### DIFF
--- a/infrastructure/ecs-main/buckets.yml
+++ b/infrastructure/ecs-main/buckets.yml
@@ -314,11 +314,11 @@ Resources:
                 HostName: ${self:custom.site.host.${self:provider.stage}}
                 ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/cli/current
             - RoutingRuleCondition:
-                  KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/atlas-operator/stable
+                  KeyPrefixEquals: ${self:custom.site.prefix.${self:provider.stage}}/atlas/operator/stable
               RedirectRule:
                 Protocol: "https"
                 HostName: ${self:custom.site.host.${self:provider.stage}}
-                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/atlas-operator/current
+                ReplaceKeyPrefixWith: ${self:custom.site.prefix.${self:provider.stage}}/atlas/operator/current
   CloudManagerBucket:
     Type: "AWS::S3::Bucket"
     Properties:


### PR DESCRIPTION
### Stories/Links:

DOP-5450

### Notes

The bucket level redirect needs to change. I will merge this on approval and redeploy the autobuilder to propagate the changes to S3 as we spoke about in standies.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README
